### PR TITLE
[DF-63]산책로 리뷰 별점보기 api 연동

### DIFF
--- a/src/apis/review.ts
+++ b/src/apis/review.ts
@@ -1,4 +1,4 @@
-import { UserReviewsType } from "./review.type";
+import { ReviewRatingType, UserReviewsType } from "./review.type";
 import { ApiResponseFormat } from "./api.type";
 import instance from "./instance";
 
@@ -10,6 +10,20 @@ export const getUserReviews = async (): Promise<{
     const response = await instance.get<
       ApiResponseFormat<{ reviews: UserReviewsType[] }>
     >("/users/reviews");
+    return response.data.data;
+  } catch (error) {
+    throw error;
+  }
+};
+
+// 산책로 리뷰 별점보기 api
+export const showReviewRating = async (
+  walkwayId: string
+): Promise<ReviewRatingType> => {
+  try {
+    const response = await instance.get<ApiResponseFormat<ReviewRatingType>>(
+      `/walkways/${walkwayId}/review/rating`
+    );
     return response.data.data;
   } catch (error) {
     throw error;

--- a/src/apis/review.type.ts
+++ b/src/apis/review.type.ts
@@ -7,3 +7,14 @@ export interface UserReviewsType {
   rating: number;
   content: string;
 }
+
+export interface ReviewRatingType {
+  //산책로 리뷰 별점보기
+  rating: number;
+  reviewCount: number;
+  five: number;
+  four: number;
+  three: number;
+  two: number;
+  one: number;
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -38,7 +38,10 @@ const NavigationPage = () => {
     },
     {
       title: "리뷰",
-      routes: [{ route: "/review/:walkwayId", name: "리뷰 작성하기" }],
+      routes: [
+        { route: "/review/:walkwayId", name: "리뷰 작성하기" },
+        { route: "/review/:walkwayId/content", name: "산책로 리뷰보기" },
+      ],
     },
     {
       title: "산책로 이용",

--- a/src/pages/review/ReviewCheck.tsx
+++ b/src/pages/review/ReviewCheck.tsx
@@ -78,12 +78,32 @@ const Label = styled.span`
 
 // TypeScript interfaces
 interface StarProps {
-  filled: boolean;
+  fill: number;
 }
 
-const Star: React.FC<StarProps> = ({ filled }) => (
-  <span style={{ color: filled ? "#ffc107" : "#e4e5e9" }}>★</span>
-);
+const Star: React.FC<StarProps> = ({ fill }) => {
+  return (
+    <div
+      style={{
+        width: "24px",
+        height: "24px",
+        background: `linear-gradient(to right, #ffc107 ${fill}%, #e4e5e9 ${fill}%)`,
+        clipPath: `polygon(
+          50% 0%,
+          61% 35%,
+          98% 35%,
+          68% 57%,
+          79% 91%,
+          50% 70%,
+          21% 91%,
+          32% 57%,
+          2% 35%,
+          39% 35%
+        )`,
+      }}
+    />
+  );
+};
 
 interface ProgressBarProps {
   percent: number;
@@ -130,9 +150,19 @@ const ReviewCheck: React.FC = () => {
     fetchReviews();
   }, [walkwayId]);
 
-  const stars = Array.from({ length: 5 }, (_, index) => (
-    <Star key={index} filled={index < Math.floor(reviewStats?.rating ?? 0)} />
-  ));
+  const StarRating: React.FC<{ rating: number }> = ({ rating }) => {
+    const fullStars = Math.floor(rating);
+    const decimalPart = (rating - fullStars) * 100;
+
+    const stars = Array.from({ length: 5 }, (_, index) => {
+      if (index < fullStars) return <Star key={index} fill={100} />;
+      if (index === fullStars) return <Star key={index} fill={decimalPart} />;
+      return <Star key={index} fill={0} />;
+    });
+
+    return <div style={{ display: "flex" }}>{stars}</div>;
+  };
+
   const ratingData = [
     { label: 5, percent: reviewStats?.five ?? 0 },
     { label: 4, percent: reviewStats?.four ?? 0 },
@@ -145,7 +175,9 @@ const ReviewCheck: React.FC = () => {
       <RatingsContainer>
         <RatingLeft>
           <StarLength>{reviewStats?.rating.toFixed(1)}</StarLength>
-          <StarContainer>{stars}</StarContainer>
+          <StarContainer>
+            <StarRating rating={reviewStats?.rating ?? 0} />
+          </StarContainer>
           <span>{`후기 ${reviewStats?.reviewCount}개`}</span>
         </RatingLeft>
         <RatingRight>


### PR DESCRIPTION
## #️⃣ 이슈 번호

close:
- #DF-63

## 📝 작업 내용

- 산책로 리뷰 별점보기 api 연동
- 소수점 별점에 따라 별 채우는 로직 수정

<img width="200px" src="https://github.com/user-attachments/assets/df519285-07a8-4267-8ddf-4fb22c076ad6"/>
