### PR TITLE
[DF-66] 산책로 상세페이지 ui 및 라우팅 완성

### DIFF
--- a/src/components/TrailCardAll_View.tsx
+++ b/src/components/TrailCardAll_View.tsx
@@ -12,6 +12,7 @@ interface Trail {
 
 interface TrailCardProps {
   trail: Trail;
+  onClick?: () => void;
 }
 
 const TrailContents = styled.div`
@@ -63,8 +64,8 @@ const Course = styled.div`
   border-radius: 10px;
 `;
 
-const TrailCardAll: React.FC<TrailCardProps> = ({ trail }) => (
-  <TrailContents key={trail.id}>
+const TrailCardAll: React.FC<TrailCardProps> = ({ trail, onClick }) => (
+  <TrailContents key={trail.id} onClick={onClick}>
     <Course />
     <MytrailInfo>
       <MytrailHeader>

--- a/src/components/map/MainMap.tsx
+++ b/src/components/map/MainMap.tsx
@@ -144,7 +144,7 @@ export const MainMap = ({
   }, [center]);
 
   const handleMarkerClick = () => {
-    navigate("/mypage/myregister/:walkwayId");
+    navigate("/recommend/detail/:walkwayId");
   };
   return (
     <MapContainer>

--- a/src/components/map/MainMap.tsx
+++ b/src/components/map/MainMap.tsx
@@ -1,217 +1,217 @@
 import { Map, MapMarker, CustomOverlayMap } from "react-kakao-maps-sdk";
-import React, { useState, useEffect } from 'react';
-import styled from 'styled-components';
-import { useNavigate } from 'react-router-dom';
+import React, { useState, useEffect } from "react";
+import styled from "styled-components";
+import { useNavigate } from "react-router-dom";
 import { theme } from "../../styles/colors/theme";
 import { ReactComponent as LocationIcon } from "../../assets/svg/LocationIcon.svg";
 import CurrentLocationMarker from "../../assets/svg/RegisteredLocation.svg";
 import SelectedLocationMarker from "../../assets/svg/UserLocation.svg";
 const MapContainer = styled.div`
-    width: 100%;
-    height: 100vh;
-    max-width: 430px;
-    margin: 0 auto;
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 0;
-    touch-action: none;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
+  width: 100%;
+  height: 100vh;
+  max-width: 430px;
+  margin: 0 auto;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 0;
+  touch-action: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 `;
 
 const MapWrapper = styled.div`
-    width: 100%;
-    height: 100%;
-    position: absolute;
-    top: 0;
-    left: 0;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
 `;
 
 const LocationButton = styled.button`
-    position: absolute;
-    bottom: 32vh;
-    left: 16px;
-    width: 40px;
-    height: 40px;
-    background-color: ${theme.White};
-    border: none;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    z-index: 1;
+  position: absolute;
+  bottom: 32vh;
+  left: 16px;
+  width: 40px;
+  height: 40px;
+  background-color: ${theme.White};
+  border: none;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 1;
 
-    &:hover {
-        background-color: #f8f8f8;
-    }
+  &:hover {
+    background-color: #f8f8f8;
+  }
 
-    &:active {
-        background-color: #f0f0f0;
-    }
+  &:active {
+    background-color: #f0f0f0;
+  }
 `;
 
 const StyledLocationIcon = styled(LocationIcon)`
-    width: 24px;
-    height: 24px;
-    fill: ${props => props.theme.Gray700};
+  width: 24px;
+  height: 24px;
+  fill: ${(props) => props.theme.Gray700};
 `;
 const MarkerTitle = styled.div`
-    background: ${props => props.theme.White};
-    padding: 5px 10px;
-    border-radius: 16px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    margin-bottom: 8px;
-    font-size: 10px;
-    font-weight: 300;
-    cursor: pointer;
-    white-space: nowrap;
-    max-width: 150px;
-    overflow: hidden;
-    text-overflow: ellipsis;
+  background: ${(props) => props.theme.White};
+  padding: 5px 10px;
+  border-radius: 16px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  margin-bottom: 8px;
+  font-size: 10px;
+  font-weight: 300;
+  cursor: pointer;
+  white-space: nowrap;
+  max-width: 150px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 interface Location {
-    lat: number;
-    lng: number;
+  lat: number;
+  lng: number;
 }
 
 interface BasicMapProps {
-    center?: Location;
-    onCenterChange?: (location: Location) => void;
-    pathName?: string;
+  center?: Location;
+  onCenterChange?: (location: Location) => void;
+  pathName?: string;
 }
 
-export const MainMap = ({ 
-    center,
-    onCenterChange,
-    pathName
+export const MainMap = ({
+  center,
+  onCenterChange,
+  pathName,
 }: BasicMapProps) => {
-    const navigate = useNavigate();
-    const [mapCenter, setMapCenter] = useState<Location>(
-        center || { lat: 37.5665, lng: 126.9780 }
-    );
-    const [userLocation, setUserLocation] = useState<Location | null>(null);
+  const navigate = useNavigate();
+  const [mapCenter, setMapCenter] = useState<Location>(
+    center || { lat: 37.5665, lng: 126.978 }
+  );
+  const [userLocation, setUserLocation] = useState<Location | null>(null);
 
-    const updateUserLocation = () => {
-        if (!navigator.geolocation) {
-            alert("위치 정보가 지원되지 않는 브라우저입니다.");
-            return;
-        }
+  const updateUserLocation = () => {
+    if (!navigator.geolocation) {
+      alert("위치 정보가 지원되지 않는 브라우저입니다.");
+      return;
+    }
 
-        navigator.geolocation.getCurrentPosition(
-            (position) => {
-                const newLocation: Location = {
-                    lat: position.coords.latitude,
-                    lng: position.coords.longitude
-                };
-                setUserLocation(newLocation);
-                setMapCenter(newLocation);
-                onCenterChange?.(newLocation);
-            },
-            (error) => {
-                console.error("Error getting user location:", error);
-                alert("위치 정보를 가져올 수 없습니다.");
-            }
-        );
-    };
-
-    useEffect(() => {
-        updateUserLocation();
-    }, []);
-
-    useEffect(() => {
-        const setVh = () => {
-            const vh = window.innerHeight * 0.01;
-            document.documentElement.style.setProperty('--vh', `${vh}px`);
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        const newLocation: Location = {
+          lat: position.coords.latitude,
+          lng: position.coords.longitude,
         };
-
-        setVh();
-        window.addEventListener('resize', setVh);
-
-        return () => window.removeEventListener('resize', setVh);
-    }, []);
-
-    useEffect(() => {
-        if (center) {
-            setMapCenter(center);
-        }
-    }, [center]);
-
-    const handleMarkerClick = () => {
-        navigate("/mypage/myregister");
-    };
-    return (
-        <MapContainer>
-            <MapWrapper>
-                <Map
-                    center={mapCenter}
-                    style={{ width: "100%", height: "100%" }}
-                    level={2}
-                    onCenterChanged={(map) => {
-                        const latlng = map.getCenter();
-                        const newCenter = {
-                            lat: latlng.getLat(),
-                            lng: latlng.getLng()
-                        };
-                        setMapCenter(newCenter);
-                        onCenterChange?.(newCenter);
-                    }}
-                >
-                    {userLocation && (
-                        <MapMarker 
-                            position={userLocation}
-                            image={{
-                                src: CurrentLocationMarker,
-                                size: {
-                                    width: 30,
-                                    height: 30
-                                },
-                                options: {
-                                    offset: {
-                                        x: 20,
-                                        y: 40
-                                    }
-                                }
-                            }}
-                        />
-                    )}
-                    
-                    {center && (
-                        <>
-                            <MapMarker 
-                                position={center}
-                                onClick={handleMarkerClick}
-                                image={{
-                                    src: SelectedLocationMarker,
-                                    size: {
-                                        width: 30,
-                                        height: 30
-                                    }
-                                }}
-                            />
-                            {pathName && (
-                                <CustomOverlayMap
-                                    position={center}
-                                    yAnchor={2}
-                                >
-                                    <MarkerTitle onClick={handleMarkerClick}>
-                                        {pathName}
-                                    </MarkerTitle>
-                                </CustomOverlayMap>
-                            )}
-                        </>
-                    )}
-                </Map>
-            </MapWrapper>
-            <LocationButton onClick={updateUserLocation} aria-label="현재 위치로 이동">
-                <StyledLocationIcon />
-            </LocationButton>
-        </MapContainer>
+        setUserLocation(newLocation);
+        setMapCenter(newLocation);
+        onCenterChange?.(newLocation);
+      },
+      (error) => {
+        console.error("Error getting user location:", error);
+        alert("위치 정보를 가져올 수 없습니다.");
+      }
     );
+  };
+
+  useEffect(() => {
+    updateUserLocation();
+  }, []);
+
+  useEffect(() => {
+    const setVh = () => {
+      const vh = window.innerHeight * 0.01;
+      document.documentElement.style.setProperty("--vh", `${vh}px`);
+    };
+
+    setVh();
+    window.addEventListener("resize", setVh);
+
+    return () => window.removeEventListener("resize", setVh);
+  }, []);
+
+  useEffect(() => {
+    if (center) {
+      setMapCenter(center);
+    }
+  }, [center]);
+
+  const handleMarkerClick = () => {
+    navigate("/mypage/myregister/:walkwayId");
+  };
+  return (
+    <MapContainer>
+      <MapWrapper>
+        <Map
+          center={mapCenter}
+          style={{ width: "100%", height: "100%" }}
+          level={2}
+          onCenterChanged={(map) => {
+            const latlng = map.getCenter();
+            const newCenter = {
+              lat: latlng.getLat(),
+              lng: latlng.getLng(),
+            };
+            setMapCenter(newCenter);
+            onCenterChange?.(newCenter);
+          }}
+        >
+          {userLocation && (
+            <MapMarker
+              position={userLocation}
+              image={{
+                src: CurrentLocationMarker,
+                size: {
+                  width: 30,
+                  height: 30,
+                },
+                options: {
+                  offset: {
+                    x: 20,
+                    y: 40,
+                  },
+                },
+              }}
+            />
+          )}
+
+          {center && (
+            <>
+              <MapMarker
+                position={center}
+                onClick={handleMarkerClick}
+                image={{
+                  src: SelectedLocationMarker,
+                  size: {
+                    width: 30,
+                    height: 30,
+                  },
+                }}
+              />
+              {pathName && (
+                <CustomOverlayMap position={center} yAnchor={2}>
+                  <MarkerTitle onClick={handleMarkerClick}>
+                    {pathName}
+                  </MarkerTitle>
+                </CustomOverlayMap>
+              )}
+            </>
+          )}
+        </Map>
+      </MapWrapper>
+      <LocationButton
+        onClick={updateUserLocation}
+        aria-label="현재 위치로 이동"
+      >
+        <StyledLocationIcon />
+      </LocationButton>
+    </MapContainer>
+  );
 };

--- a/src/components/myregister/index.tsx
+++ b/src/components/myregister/index.tsx
@@ -110,6 +110,7 @@ const Button = styled.button`
   border: none;
   font-size: 16px;
   font-weight: 500;
+  margin-top: 0.6rem;
 `;
 
 export default function MyRegister() {

--- a/src/components/myregister/index.tsx
+++ b/src/components/myregister/index.tsx
@@ -15,9 +15,13 @@ import { useNavigate } from "react-router-dom";
 const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
   padding: 20px;
   align-items: center;
-  max-height: 100vh;
+  min-height: 100%;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 const ContentWrapper = styled.div`
   display: flex;
@@ -30,15 +34,18 @@ const Content = styled.div`
   justify-content: space-between;
   align-items: center;
 `;
+const TrailInfoContainer = styled.div`
+  display: flex;
+  justify-content: center;
+`;
 const Title = styled.div`
-  font-size: 18px;
+  font-size: 1.125rem;
   font-weight: 600;
   margin: 10px;
 `;
 const ShowField = styled.div`
-  width: 80vw;
+  max-width: 80vw;
   height: 50vh;
-  max-width: 322px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -48,11 +55,12 @@ const Img = styled.img`
   background: #c7c7c7;
   box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.25);
   border-radius: 20px 20px 0px 0px;
-  max-height: 276px;
+  height: 35vh;
+  width: 100%;
 `;
 const FieldContent = styled.div`
-  width: 322px;
-  height: 109px;
+  width: 100%;
+  height: 15vh;
   background: #ffffff;
   box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.25);
   border-radius: 0px 0px 10px 10px;
@@ -97,8 +105,8 @@ const Hashtag = styled.div`
 const Button = styled.button`
   background-color: #888;
   color: #ffffff;
-  width: 356px;
-  height: 52px;
+  width: 100%;
+  height: 3.25rem;
   border: none;
   font-size: 16px;
   font-weight: 500;
@@ -132,7 +140,9 @@ export default function MyRegister() {
           <ToggleSwitch />
         </Content>
         <Title>가을에 걷기 좋은 산책로</Title>
-        <TrailInfo duration={"12:00"} distance={53} />
+        <TrailInfoContainer>
+          <TrailInfo duration={"12:00"} distance={53} />
+        </TrailInfoContainer>
       </ContentWrapper>
       <ShowField>
         <Img src={trail} alt="Trail" />

--- a/src/navigator/routes.tsx
+++ b/src/navigator/routes.tsx
@@ -12,6 +12,8 @@ import DetailUsing from "../pages/usingtrail/detail_using";
 import TrailReviewPage from "../pages/mypage/TrailReviewPage";
 import NavigationPage from "../pages";
 import ReviewCheck from "../pages/review/ReviewCheck";
+import RecommendTrail from "../pages/detailpage/recommend_trail";
+import TrailLiked from "../pages/detailpage/TrailLiked";
 
 export const routes = [
   {
@@ -25,6 +27,11 @@ export const routes = [
     headerOptions: { headerShown: false },
   },
   {
+    path: "/recommend/detail/:walkwayId",
+    component: RecommendTrail,
+    headerOptions: { title: "산책로", showBackButton: true },
+  },
+  {
     path: "/mypage",
     component: MyPage,
     headerOptions: { title: "마이 페이지", showBackButton: true },
@@ -33,6 +40,11 @@ export const routes = [
     path: "/mypage/TrailList",
     component: TrailListPage,
     headerOptions: { title: "전체보기", showBackButton: true },
+  },
+  {
+    path: "/mypage/myregister/:walkwayId",
+    component: MyRegister,
+    headerOptions: { title: "내 산책로", showBackButton: true },
   },
   {
     path: "/mypage/TrailLikeList",
@@ -44,7 +56,11 @@ export const routes = [
     component: TrailReviewPage,
     headerOptions: { title: "리뷰보기", showBackButton: true },
   },
-
+  {
+    path: "/mypage/TrailLikeList/detail/:walkwayId",
+    component: TrailLiked,
+    headerOptions: { title: "찜한 산책로", showBackButton: true },
+  },
   {
     path: "/newway",
     component: NewWay,
@@ -59,11 +75,6 @@ export const routes = [
     path: "/signin",
     component: SignIn,
     headerOptions: { headerShown: false },
-  },
-  {
-    path: "/mypage/myregister",
-    component: MyRegister,
-    headerOptions: { title: "내 산책로", showBackButton: true },
   },
   {
     path: "/review/:walkwayId/content",
@@ -81,7 +92,7 @@ export const routes = [
     headerOptions: { title: "산책로 이용하기", showBackButton: true },
   },
   {
-    path: "/usingtrail/detail/:walkwayId",
+    path: "/usedtrail/detail/:walkwayId",
     component: DetailUsing,
     headerOptions: { title: "산책로", showBackButton: true },
   },

--- a/src/pages/detailpage/TrailLiked.tsx
+++ b/src/pages/detailpage/TrailLiked.tsx
@@ -1,6 +1,5 @@
 import styled from "styled-components";
 import DateDisplay from "src/components/newway_register/DateDisplay";
-import ToggleSwitch from "src/components/newway_register/ToggleSwitch";
 import TrailInfo from "src/components/newway_register/TrailInfo";
 import trail from "src/assets/images/trail.png";
 import {
@@ -11,6 +10,8 @@ import {
 import { IoMdHeartEmpty, IoMdHeart } from "react-icons/io";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { theme } from "src/styles/colors/theme";
+import { BsBookmark, BsBookmarkFill } from "react-icons/bs";
 
 const Wrapper = styled.div`
   display: flex;
@@ -60,9 +61,14 @@ const FieldContent = styled.div`
 const IconWrapper = styled.div`
   display: flex;
   align-items: center;
-  justify-content: space-around;
-  width: 150px;
+  justify-content: space-between;
   margin: 10px;
+`;
+const LeftIcon = styled.div`
+  display: flex;
+  align-items: center;
+  width: 150px;
+  gap: 10px;
 `;
 interface IconButtonProps {
   active?: boolean;
@@ -72,6 +78,9 @@ const IconButton = styled.div<IconButtonProps>`
   align-items: center;
   font-size: 12px;
   color: ${(props) => (props.active ? "red" : "black")};
+`;
+const BookmarkButton = styled.div<IconButtonProps>`
+  display: flex;
 `;
 const ReviewCount = styled.div`
   font-size: 12px;
@@ -95,7 +104,7 @@ const Hashtag = styled.div`
   flex-shrink: 0;
 `;
 const Button = styled.button`
-  background-color: #888;
+  background-color: ${theme.Green500};
   color: #ffffff;
   width: 356px;
   height: 52px;
@@ -111,6 +120,7 @@ export default function TrailLiked() {
   const [reviewCount, setReviewCount] = useState<number>(0);
   const [isHeartActive, setIsHeartActive] = useState<boolean>(false);
   const [isStarActive, setIsStarActive] = useState<boolean>(false);
+  const [isBookmarkActive, setIsBookmarkActive] = useState<boolean>(false);
   const [hashtags, setHashtgs] = useState<String[]>(["청계천", "호수"]);
 
   const toggleHeart = (): void => {
@@ -121,6 +131,9 @@ export default function TrailLiked() {
     setIsStarActive(!isStarActive);
     setStarCount((prev) => (isStarActive ? prev - 1 : prev + 1));
   };
+  const toggleBookmark = (): void => {
+    setIsBookmarkActive(!isBookmarkActive);
+  };
   const goToReviews = (): void => {
     navigate("/reviews");
   };
@@ -129,7 +142,6 @@ export default function TrailLiked() {
       <ContentWrapper>
         <Content>
           <DateDisplay />
-          <ToggleSwitch />
         </Content>
         <Title>가을에 걷기 좋은 산책로</Title>
         <TrailInfo duration={"12:00"} distance={53} />
@@ -138,26 +150,31 @@ export default function TrailLiked() {
         <Img src={trail} alt="Trail" />
         <FieldContent>
           <IconWrapper>
-            <IconButton active={isHeartActive} onClick={toggleHeart}>
-              {isHeartActive ? (
-                <IoMdHeart size={20} />
-              ) : (
-                <IoMdHeartEmpty size={20} />
-              )}{" "}
-              {heartCount}
-            </IconButton>
-            <IconButton active={isStarActive} onClick={toggleStar}>
-              {isStarActive ? (
-                <MdOutlineStar size={20} />
-              ) : (
-                <MdOutlineStarBorder size={20} />
-              )}{" "}
-              {starCount}
-            </IconButton>
-            <ReviewCount>리뷰 {reviewCount}개</ReviewCount>
-            <IconButton onClick={goToReviews}>
-              <MdArrowForwardIos />
-            </IconButton>
+            <LeftIcon>
+              <IconButton active={isHeartActive} onClick={toggleHeart}>
+                {isHeartActive ? (
+                  <IoMdHeart size={20} />
+                ) : (
+                  <IoMdHeartEmpty size={20} />
+                )}{" "}
+                {heartCount}
+              </IconButton>
+              <IconButton active={isStarActive} onClick={toggleStar}>
+                {isStarActive ? (
+                  <MdOutlineStar size={20} />
+                ) : (
+                  <MdOutlineStarBorder size={20} />
+                )}{" "}
+                {starCount}
+              </IconButton>
+              <ReviewCount>리뷰 {reviewCount}개</ReviewCount>
+              <IconButton onClick={goToReviews}>
+                <MdArrowForwardIos />
+              </IconButton>
+            </LeftIcon>
+            <BookmarkButton active={isBookmarkActive} onClick={toggleBookmark}>
+              {isBookmarkActive ? <BsBookmark /> : <BsBookmarkFill />}
+            </BookmarkButton>
           </IconWrapper>
 
           <Explanation>풍경 좋은 청계천 근처 산책로! 걸어보세용</Explanation>
@@ -168,7 +185,7 @@ export default function TrailLiked() {
           </HashtagContainer>
         </FieldContent>
       </ShowField>
-      <Button>수정하기</Button>
+      <Button>이용하기</Button>
     </Wrapper>
   );
 }

--- a/src/pages/detailpage/TrailLiked.tsx
+++ b/src/pages/detailpage/TrailLiked.tsx
@@ -1,0 +1,174 @@
+import styled from "styled-components";
+import DateDisplay from "src/components/newway_register/DateDisplay";
+import ToggleSwitch from "src/components/newway_register/ToggleSwitch";
+import TrailInfo from "src/components/newway_register/TrailInfo";
+import trail from "src/assets/images/trail.png";
+import {
+  MdOutlineStarBorder,
+  MdOutlineStar,
+  MdArrowForwardIos,
+} from "react-icons/md";
+import { IoMdHeartEmpty, IoMdHeart } from "react-icons/io";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 20px;
+  align-items: center;
+  max-height: 100vh;
+`;
+const ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+const Content = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+`;
+const Title = styled.div`
+  font-size: 18px;
+  font-weight: 600;
+  margin: 10px;
+`;
+const ShowField = styled.div`
+  width: 80vw;
+  height: 50vh;
+  max-width: 322px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 10px auto;
+`;
+const Img = styled.img`
+  background: #c7c7c7;
+  box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.25);
+  border-radius: 20px 20px 0px 0px;
+  max-height: 276px;
+`;
+const FieldContent = styled.div`
+  width: 322px;
+  height: 109px;
+  background: #ffffff;
+  box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.25);
+  border-radius: 0px 0px 10px 10px;
+`;
+const IconWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  width: 150px;
+  margin: 10px;
+`;
+interface IconButtonProps {
+  active?: boolean;
+}
+const IconButton = styled.div<IconButtonProps>`
+  display: flex;
+  align-items: center;
+  font-size: 12px;
+  color: ${(props) => (props.active ? "red" : "black")};
+`;
+const ReviewCount = styled.div`
+  font-size: 12px;
+`;
+const Explanation = styled.div`
+  font-size: 12px;
+  margin: 10px;
+`;
+const HashtagContainer = styled.div`
+  display: flex;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  gap: 5px;
+  margin: 10px;
+`;
+
+const Hashtag = styled.div`
+  font-size: 12px;
+  font-weight: 600;
+  margin: 2px;
+  flex-shrink: 0;
+`;
+const Button = styled.button`
+  background-color: #888;
+  color: #ffffff;
+  width: 356px;
+  height: 52px;
+  border: none;
+  font-size: 16px;
+  font-weight: 500;
+`;
+
+export default function TrailLiked() {
+  const navigate = useNavigate();
+  const [heartCount, setHeartCount] = useState<number>(0);
+  const [starCount, setStarCount] = useState<number>(0);
+  const [reviewCount, setReviewCount] = useState<number>(0);
+  const [isHeartActive, setIsHeartActive] = useState<boolean>(false);
+  const [isStarActive, setIsStarActive] = useState<boolean>(false);
+  const [hashtags, setHashtgs] = useState<String[]>(["청계천", "호수"]);
+
+  const toggleHeart = (): void => {
+    setIsHeartActive(!isHeartActive);
+    setHeartCount((prev) => (isHeartActive ? prev - 1 : prev + 1));
+  };
+  const toggleStar = (): void => {
+    setIsStarActive(!isStarActive);
+    setStarCount((prev) => (isStarActive ? prev - 1 : prev + 1));
+  };
+  const goToReviews = (): void => {
+    navigate("/reviews");
+  };
+  return (
+    <Wrapper>
+      <ContentWrapper>
+        <Content>
+          <DateDisplay />
+          <ToggleSwitch />
+        </Content>
+        <Title>가을에 걷기 좋은 산책로</Title>
+        <TrailInfo duration={"12:00"} distance={53} />
+      </ContentWrapper>
+      <ShowField>
+        <Img src={trail} alt="Trail" />
+        <FieldContent>
+          <IconWrapper>
+            <IconButton active={isHeartActive} onClick={toggleHeart}>
+              {isHeartActive ? (
+                <IoMdHeart size={20} />
+              ) : (
+                <IoMdHeartEmpty size={20} />
+              )}{" "}
+              {heartCount}
+            </IconButton>
+            <IconButton active={isStarActive} onClick={toggleStar}>
+              {isStarActive ? (
+                <MdOutlineStar size={20} />
+              ) : (
+                <MdOutlineStarBorder size={20} />
+              )}{" "}
+              {starCount}
+            </IconButton>
+            <ReviewCount>리뷰 {reviewCount}개</ReviewCount>
+            <IconButton onClick={goToReviews}>
+              <MdArrowForwardIos />
+            </IconButton>
+          </IconWrapper>
+
+          <Explanation>풍경 좋은 청계천 근처 산책로! 걸어보세용</Explanation>
+          <HashtagContainer>
+            {hashtags.map((hashtag, index) => (
+              <Hashtag key={index}> #{hashtag}</Hashtag>
+            ))}
+          </HashtagContainer>
+        </FieldContent>
+      </ShowField>
+      <Button>수정하기</Button>
+    </Wrapper>
+  );
+}

--- a/src/pages/detailpage/TrailLiked.tsx
+++ b/src/pages/detailpage/TrailLiked.tsx
@@ -16,9 +16,13 @@ import { BsBookmark, BsBookmarkFill } from "react-icons/bs";
 const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
   padding: 20px;
   align-items: center;
-  max-height: 100vh;
+  min-height: 100%;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 const ContentWrapper = styled.div`
   display: flex;
@@ -31,8 +35,12 @@ const Content = styled.div`
   justify-content: space-between;
   align-items: center;
 `;
+const TrailInfoContainer = styled.div`
+  display: flex;
+  justify-content: center;
+`;
 const Title = styled.div`
-  font-size: 18px;
+  font-size: 1.125rem;
   font-weight: 600;
   margin: 10px;
 `;
@@ -49,11 +57,12 @@ const Img = styled.img`
   background: #c7c7c7;
   box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.25);
   border-radius: 20px 20px 0px 0px;
-  max-height: 276px;
+  height: 35vh;
+  width: 100%;
 `;
 const FieldContent = styled.div`
-  width: 322px;
-  height: 109px;
+  width: 100%;
+  height: 15vh;
   background: #ffffff;
   box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.25);
   border-radius: 0px 0px 10px 10px;
@@ -111,6 +120,7 @@ const Button = styled.button`
   border: none;
   font-size: 16px;
   font-weight: 500;
+  margin-top: 0.6rem;
 `;
 
 export default function TrailLiked() {
@@ -144,7 +154,9 @@ export default function TrailLiked() {
           <DateDisplay />
         </Content>
         <Title>가을에 걷기 좋은 산책로</Title>
-        <TrailInfo duration={"12:00"} distance={53} />
+        <TrailInfoContainer>
+          <TrailInfo duration={"12:00"} distance={53} />
+        </TrailInfoContainer>
       </ContentWrapper>
       <ShowField>
         <Img src={trail} alt="Trail" />

--- a/src/pages/detailpage/recommend_trail.tsx
+++ b/src/pages/detailpage/recommend_trail.tsx
@@ -1,6 +1,5 @@
 import styled from "styled-components";
 import DateDisplay from "src/components/newway_register/DateDisplay";
-import ToggleSwitch from "src/components/newway_register/ToggleSwitch";
 import TrailInfo from "src/components/newway_register/TrailInfo";
 import trail from "src/assets/images/trail.png";
 import {
@@ -11,6 +10,8 @@ import {
 import { IoMdHeartEmpty, IoMdHeart } from "react-icons/io";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { theme } from "src/styles/colors/theme";
+import { BsBookmark, BsBookmarkFill } from "react-icons/bs";
 
 const Wrapper = styled.div`
   display: flex;
@@ -60,9 +61,14 @@ const FieldContent = styled.div`
 const IconWrapper = styled.div`
   display: flex;
   align-items: center;
-  justify-content: space-around;
-  width: 150px;
+  justify-content: space-between;
   margin: 10px;
+`;
+const LeftIcon = styled.div`
+  display: flex;
+  align-items: center;
+  width: 150px;
+  gap: 10px;
 `;
 interface IconButtonProps {
   active?: boolean;
@@ -72,6 +78,9 @@ const IconButton = styled.div<IconButtonProps>`
   align-items: center;
   font-size: 12px;
   color: ${(props) => (props.active ? "red" : "black")};
+`;
+const BookmarkButton = styled.div<IconButtonProps>`
+  display: flex;
 `;
 const ReviewCount = styled.div`
   font-size: 12px;
@@ -95,7 +104,7 @@ const Hashtag = styled.div`
   flex-shrink: 0;
 `;
 const Button = styled.button`
-  background-color: #888;
+  background-color: ${theme.Green500};
   color: #ffffff;
   width: 356px;
   height: 52px;
@@ -111,6 +120,7 @@ export default function RecommendTrail() {
   const [reviewCount, setReviewCount] = useState<number>(0);
   const [isHeartActive, setIsHeartActive] = useState<boolean>(false);
   const [isStarActive, setIsStarActive] = useState<boolean>(false);
+  const [isBookmarkActive, setIsBookmarkActive] = useState<boolean>(false);
   const [hashtags, setHashtgs] = useState<String[]>(["청계천", "호수"]);
 
   const toggleHeart = (): void => {
@@ -121,6 +131,9 @@ export default function RecommendTrail() {
     setIsStarActive(!isStarActive);
     setStarCount((prev) => (isStarActive ? prev - 1 : prev + 1));
   };
+  const toggleBookmark = (): void => {
+    setIsBookmarkActive(!isBookmarkActive);
+  };
   const goToReviews = (): void => {
     navigate("/reviews");
   };
@@ -129,7 +142,6 @@ export default function RecommendTrail() {
       <ContentWrapper>
         <Content>
           <DateDisplay />
-          <ToggleSwitch />
         </Content>
         <Title>가을에 걷기 좋은 산책로</Title>
         <TrailInfo duration={"12:00"} distance={53} />
@@ -138,26 +150,31 @@ export default function RecommendTrail() {
         <Img src={trail} alt="Trail" />
         <FieldContent>
           <IconWrapper>
-            <IconButton active={isHeartActive} onClick={toggleHeart}>
-              {isHeartActive ? (
-                <IoMdHeart size={20} />
-              ) : (
-                <IoMdHeartEmpty size={20} />
-              )}{" "}
-              {heartCount}
-            </IconButton>
-            <IconButton active={isStarActive} onClick={toggleStar}>
-              {isStarActive ? (
-                <MdOutlineStar size={20} />
-              ) : (
-                <MdOutlineStarBorder size={20} />
-              )}{" "}
-              {starCount}
-            </IconButton>
-            <ReviewCount>리뷰 {reviewCount}개</ReviewCount>
-            <IconButton onClick={goToReviews}>
-              <MdArrowForwardIos />
-            </IconButton>
+            <LeftIcon>
+              <IconButton active={isHeartActive} onClick={toggleHeart}>
+                {isHeartActive ? (
+                  <IoMdHeart size={20} />
+                ) : (
+                  <IoMdHeartEmpty size={20} />
+                )}{" "}
+                {heartCount}
+              </IconButton>
+              <IconButton active={isStarActive} onClick={toggleStar}>
+                {isStarActive ? (
+                  <MdOutlineStar size={20} />
+                ) : (
+                  <MdOutlineStarBorder size={20} />
+                )}{" "}
+                {starCount}
+              </IconButton>
+              <ReviewCount>리뷰 {reviewCount}개</ReviewCount>
+              <IconButton onClick={goToReviews}>
+                <MdArrowForwardIos />
+              </IconButton>
+            </LeftIcon>
+            <BookmarkButton active={isBookmarkActive} onClick={toggleBookmark}>
+              {isBookmarkActive ? <BsBookmarkFill /> : <BsBookmark />}
+            </BookmarkButton>
           </IconWrapper>
 
           <Explanation>풍경 좋은 청계천 근처 산책로! 걸어보세용</Explanation>
@@ -168,7 +185,7 @@ export default function RecommendTrail() {
           </HashtagContainer>
         </FieldContent>
       </ShowField>
-      <Button>수정하기</Button>
+      <Button>이용하기</Button>
     </Wrapper>
   );
 }

--- a/src/pages/detailpage/recommend_trail.tsx
+++ b/src/pages/detailpage/recommend_trail.tsx
@@ -1,0 +1,174 @@
+import styled from "styled-components";
+import DateDisplay from "src/components/newway_register/DateDisplay";
+import ToggleSwitch from "src/components/newway_register/ToggleSwitch";
+import TrailInfo from "src/components/newway_register/TrailInfo";
+import trail from "src/assets/images/trail.png";
+import {
+  MdOutlineStarBorder,
+  MdOutlineStar,
+  MdArrowForwardIos,
+} from "react-icons/md";
+import { IoMdHeartEmpty, IoMdHeart } from "react-icons/io";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 20px;
+  align-items: center;
+  max-height: 100vh;
+`;
+const ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+const Content = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+`;
+const Title = styled.div`
+  font-size: 18px;
+  font-weight: 600;
+  margin: 10px;
+`;
+const ShowField = styled.div`
+  width: 80vw;
+  height: 50vh;
+  max-width: 322px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 10px auto;
+`;
+const Img = styled.img`
+  background: #c7c7c7;
+  box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.25);
+  border-radius: 20px 20px 0px 0px;
+  max-height: 276px;
+`;
+const FieldContent = styled.div`
+  width: 322px;
+  height: 109px;
+  background: #ffffff;
+  box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.25);
+  border-radius: 0px 0px 10px 10px;
+`;
+const IconWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  width: 150px;
+  margin: 10px;
+`;
+interface IconButtonProps {
+  active?: boolean;
+}
+const IconButton = styled.div<IconButtonProps>`
+  display: flex;
+  align-items: center;
+  font-size: 12px;
+  color: ${(props) => (props.active ? "red" : "black")};
+`;
+const ReviewCount = styled.div`
+  font-size: 12px;
+`;
+const Explanation = styled.div`
+  font-size: 12px;
+  margin: 10px;
+`;
+const HashtagContainer = styled.div`
+  display: flex;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  gap: 5px;
+  margin: 10px;
+`;
+
+const Hashtag = styled.div`
+  font-size: 12px;
+  font-weight: 600;
+  margin: 2px;
+  flex-shrink: 0;
+`;
+const Button = styled.button`
+  background-color: #888;
+  color: #ffffff;
+  width: 356px;
+  height: 52px;
+  border: none;
+  font-size: 16px;
+  font-weight: 500;
+`;
+
+export default function RecommendTrail() {
+  const navigate = useNavigate();
+  const [heartCount, setHeartCount] = useState<number>(0);
+  const [starCount, setStarCount] = useState<number>(0);
+  const [reviewCount, setReviewCount] = useState<number>(0);
+  const [isHeartActive, setIsHeartActive] = useState<boolean>(false);
+  const [isStarActive, setIsStarActive] = useState<boolean>(false);
+  const [hashtags, setHashtgs] = useState<String[]>(["청계천", "호수"]);
+
+  const toggleHeart = (): void => {
+    setIsHeartActive(!isHeartActive);
+    setHeartCount((prev) => (isHeartActive ? prev - 1 : prev + 1));
+  };
+  const toggleStar = (): void => {
+    setIsStarActive(!isStarActive);
+    setStarCount((prev) => (isStarActive ? prev - 1 : prev + 1));
+  };
+  const goToReviews = (): void => {
+    navigate("/reviews");
+  };
+  return (
+    <Wrapper>
+      <ContentWrapper>
+        <Content>
+          <DateDisplay />
+          <ToggleSwitch />
+        </Content>
+        <Title>가을에 걷기 좋은 산책로</Title>
+        <TrailInfo duration={"12:00"} distance={53} />
+      </ContentWrapper>
+      <ShowField>
+        <Img src={trail} alt="Trail" />
+        <FieldContent>
+          <IconWrapper>
+            <IconButton active={isHeartActive} onClick={toggleHeart}>
+              {isHeartActive ? (
+                <IoMdHeart size={20} />
+              ) : (
+                <IoMdHeartEmpty size={20} />
+              )}{" "}
+              {heartCount}
+            </IconButton>
+            <IconButton active={isStarActive} onClick={toggleStar}>
+              {isStarActive ? (
+                <MdOutlineStar size={20} />
+              ) : (
+                <MdOutlineStarBorder size={20} />
+              )}{" "}
+              {starCount}
+            </IconButton>
+            <ReviewCount>리뷰 {reviewCount}개</ReviewCount>
+            <IconButton onClick={goToReviews}>
+              <MdArrowForwardIos />
+            </IconButton>
+          </IconWrapper>
+
+          <Explanation>풍경 좋은 청계천 근처 산책로! 걸어보세용</Explanation>
+          <HashtagContainer>
+            {hashtags.map((hashtag, index) => (
+              <Hashtag key={index}> #{hashtag}</Hashtag>
+            ))}
+          </HashtagContainer>
+        </FieldContent>
+      </ShowField>
+      <Button>수정하기</Button>
+    </Wrapper>
+  );
+}

--- a/src/pages/detailpage/recommend_trail.tsx
+++ b/src/pages/detailpage/recommend_trail.tsx
@@ -16,9 +16,13 @@ import { BsBookmark, BsBookmarkFill } from "react-icons/bs";
 const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
   padding: 20px;
   align-items: center;
-  max-height: 100vh;
+  min-height: 100%;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 const ContentWrapper = styled.div`
   display: flex;
@@ -31,8 +35,12 @@ const Content = styled.div`
   justify-content: space-between;
   align-items: center;
 `;
+const TrailInfoContainer = styled.div`
+  display: flex;
+  justify-content: center;
+`;
 const Title = styled.div`
-  font-size: 18px;
+  font-size: 1.125rem;
   font-weight: 600;
   margin: 10px;
 `;
@@ -49,11 +57,12 @@ const Img = styled.img`
   background: #c7c7c7;
   box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.25);
   border-radius: 20px 20px 0px 0px;
-  max-height: 276px;
+  height: 35vh;
+  width: 100%;
 `;
 const FieldContent = styled.div`
-  width: 322px;
-  height: 109px;
+  width: 100%;
+  height: 15vh;
   background: #ffffff;
   box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.25);
   border-radius: 0px 0px 10px 10px;
@@ -111,6 +120,7 @@ const Button = styled.button`
   border: none;
   font-size: 16px;
   font-weight: 500;
+  margin-top: 0.6rem;
 `;
 
 export default function RecommendTrail() {
@@ -144,7 +154,9 @@ export default function RecommendTrail() {
           <DateDisplay />
         </Content>
         <Title>가을에 걷기 좋은 산책로</Title>
-        <TrailInfo duration={"12:00"} distance={53} />
+        <TrailInfoContainer>
+          <TrailInfo duration={"12:00"} distance={53} />
+        </TrailInfoContainer>
       </ContentWrapper>
       <ShowField>
         <Img src={trail} alt="Trail" />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -31,8 +31,12 @@ const NavigationPage = () => {
         },
         { route: "/mypage/ReviewList", name: "내가 등록한 리뷰 리스트 보기" },
         {
-          route: "/mypage/myregister",
+          route: "/mypage/myregister/:walkwayId",
           name: "내 산책로 상세 페이지 단건 조회",
+        },
+        {
+          route: "/mypage/TrailLikeList/detail/:walkwayId",
+          name: "내가 찜한 상세 페이지 단건 조회",
         },
       ],
     },
@@ -48,8 +52,12 @@ const NavigationPage = () => {
       routes: [
         { route: "/usingtrail", name: "다른 유저가 등록한 산책로 이용하기" },
         {
-          route: "/usingtrail/detail/:walkwayId",
+          route: "/usedtrail/detail/:walkwayId",
           name: "다른 유저가 등록한 산책로 상세 페이지",
+        },
+        {
+          route: "/recommend/detail/:walkwayId",
+          name: "산책로 추천에서 조회된 상세 페이지",
         },
       ],
     },

--- a/src/pages/mypage/TrailListLikePage.tsx
+++ b/src/pages/mypage/TrailListLikePage.tsx
@@ -55,14 +55,20 @@ function TrailLikeListPage() {
       tag: "#한국외대 #자취생_산책로",
     },
   ];
-
+  const handleCardClick = () => {
+    navigate("/mypage/TrailLikeList/detail/:walkwayId"); //api연동 시 id 연결되도록 수정
+  };
   return (
     <>
       <Header title={title} showBackButton={true} onBack={() => navigate(-1)} />
       <Wrapper>
         <List>
           {trails.map((trail) => (
-            <TrailCardAll key={trail.id} trail={trail} />
+            <TrailCardAll
+              key={trail.id}
+              trail={trail}
+              onClick={handleCardClick}
+            />
           ))}
         </List>
       </Wrapper>

--- a/src/pages/mypage/TrailListPage.tsx
+++ b/src/pages/mypage/TrailListPage.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import TrailCardAll from "../../components/TrailCardAll_View";
+import { useNavigate } from "react-router-dom";
 
 interface Trail {
   id: number;
@@ -30,6 +31,7 @@ const List = styled.div`
 `;
 
 function TrailListPage() {
+  const navigate = useNavigate();
   const trails: Trail[] = [
     {
       id: 1,
@@ -73,11 +75,18 @@ function TrailListPage() {
     },
   ];
 
+  const handleCardClick = () => {
+    navigate("/mypage/myregister/:walkwayId"); //api 연동시 id 연결되도록 수정
+  };
   return (
     <Wrapper>
       <List>
         {trails.map((trail) => (
-          <TrailCardAll key={trail.id} trail={trail} />
+          <TrailCardAll
+            key={trail.id}
+            trail={trail}
+            onClick={handleCardClick}
+          />
         ))}
       </List>
     </Wrapper>

--- a/src/pages/usingtrail/detail_using.tsx
+++ b/src/pages/usingtrail/detail_using.tsx
@@ -13,6 +13,7 @@ import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { theme } from "src/styles/colors/theme";
 import { toggleLike } from "src/apis/likedWalkway";
+import { BsBookmark, BsBookmarkFill } from "react-icons/bs";
 
 const Wrapper = styled.div`
   display: flex;
@@ -89,9 +90,14 @@ const FieldContent = styled.div`
 const IconWrapper = styled.div`
   display: flex;
   align-items: center;
-  justify-content: space-around;
-  width: 9.375rem;
-  margin: 0.375rem;
+  justify-content: space-between;
+  margin: 10px;
+`;
+const LeftIcon = styled.div`
+  display: flex;
+  align-items: center;
+  width: 150px;
+  gap: 10px;
 `;
 interface IconButtonProps {
   active?: boolean;
@@ -99,8 +105,11 @@ interface IconButtonProps {
 const IconButton = styled.div<IconButtonProps>`
   display: flex;
   align-items: center;
-  font-size: 0.75rem;
+  font-size: 12px;
   color: ${(props) => (props.active ? "red" : "black")};
+`;
+const BookmarkButton = styled.div<IconButtonProps>`
+  display: flex;
 `;
 const ReviewCount = styled.div`
   font-size: 0.75rem;
@@ -168,6 +177,7 @@ export default function DetailUsing() {
   const [reviewCount, setReviewCount] = useState<number>(0);
   const [isHeartActive, setIsHeartActive] = useState<boolean>(false);
   const [isStarActive, setIsStarActive] = useState<boolean>(false);
+  const [isBookmarkActive, setIsBookmarkActive] = useState<boolean>(false);
   const [hashtags, setHashtags] = useState<String[]>(["청계천", "호수"]);
 
   const toggleHeart = async (): Promise<void> => {
@@ -184,6 +194,9 @@ export default function DetailUsing() {
   const toggleStar = (): void => {
     setIsStarActive(!isStarActive);
     setStarCount((prev) => (isStarActive ? prev - 1 : prev + 1));
+  };
+  const toggleBookmark = (): void => {
+    setIsBookmarkActive(!isBookmarkActive);
   };
   const goToReviews = (): void => {
     navigate(`/review/${walkwayId}/content`);
@@ -204,26 +217,31 @@ export default function DetailUsing() {
         <Img src={trail} alt="Trail" />
         <FieldContent>
           <IconWrapper>
-            <IconButton active={isHeartActive} onClick={toggleHeart}>
-              {isHeartActive ? (
-                <IoMdHeart size={20} />
-              ) : (
-                <IoMdHeartEmpty size={20} />
-              )}{" "}
-              {heartCount}
-            </IconButton>
-            <IconButton active={isStarActive} onClick={toggleStar}>
-              {isStarActive ? (
-                <MdOutlineStar size={20} />
-              ) : (
-                <MdOutlineStarBorder size={20} />
-              )}{" "}
-              {starCount}
-            </IconButton>
-            <ReviewCount>리뷰 {reviewCount}개</ReviewCount>
-            <IconButton onClick={goToReviews}>
-              <MdArrowForwardIos />
-            </IconButton>
+            <LeftIcon>
+              <IconButton active={isHeartActive} onClick={toggleHeart}>
+                {isHeartActive ? (
+                  <IoMdHeart size={20} />
+                ) : (
+                  <IoMdHeartEmpty size={20} />
+                )}{" "}
+                {heartCount}
+              </IconButton>
+              <IconButton active={isStarActive} onClick={toggleStar}>
+                {isStarActive ? (
+                  <MdOutlineStar size={20} />
+                ) : (
+                  <MdOutlineStarBorder size={20} />
+                )}{" "}
+                {starCount}
+              </IconButton>
+              <ReviewCount>리뷰 {reviewCount}개</ReviewCount>
+              <IconButton onClick={goToReviews}>
+                <MdArrowForwardIos />
+              </IconButton>
+            </LeftIcon>
+            <BookmarkButton active={isBookmarkActive} onClick={toggleBookmark}>
+              {isBookmarkActive ? <BsBookmarkFill /> : <BsBookmark />}
+            </BookmarkButton>
           </IconWrapper>
 
           <Explanation>풍경 좋은 청계천 근처 산책로! 걸어보세용</Explanation>

--- a/src/pages/usingtrail/detail_using.tsx
+++ b/src/pages/usingtrail/detail_using.tsx
@@ -56,35 +56,24 @@ const Title = styled.div`
   }
 `;
 const ShowField = styled.div`
-  width: 90%;
-  max-width: 20rem;
-  height: auto;
+  width: 80vw;
+  height: 45vh;
+  max-width: 322px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin: 1.875rem auto;
-  @media (max-width: 375px) {
-    width: 80%;
-    height: auto;
-    max-height: 18.75rem;
-    margin: 0 0.625rem;
-  }
+  margin: 10px auto;
 `;
-
 const Img = styled.img`
   background: #c7c7c7;
   box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.25);
-  border-radius: 1.25rem 1.25rem 0px 0px;
+  border-radius: 20px 20px 0px 0px;
+  height: 30vh;
   width: 100%;
-  height: 17rem;
-  @media (max-width: 375px) {
-    max-height: 13rem;
-  }
 `;
 const FieldContent = styled.div`
   width: 100%;
-  max-width: 20rem;
-  height: auto;
+  height: 15vh;
   background: #ffffff;
   box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.25);
   border-radius: 0px 0px 0.625rem 0.625rem;

--- a/src/pages/usingtrail/detail_using.tsx
+++ b/src/pages/usingtrail/detail_using.tsx
@@ -21,8 +21,10 @@ const Wrapper = styled.div`
   justify-content: space-between;
   padding: 1.25rem;
   align-items: center;
-  height: 85vh;
-  max-height: 100vh;
+  min-height: 100%;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 const ContentWrapper = styled.div`
   display: flex;

--- a/src/pages/usingtrail/index.tsx
+++ b/src/pages/usingtrail/index.tsx
@@ -139,7 +139,7 @@ function Usingtrail() {
     setIsWalking(false);
 
     // 상세페이지로 이동
-    navigate("/usingtrail/detail", {
+    navigate("/usedtrail/detail/:walkwayId", {
       state: pathData,
     });
   };


### PR DESCRIPTION
## #️⃣ 이슈 번호

close:
- #DF-66

## 📝 작업 내용

- 산책로 상세페이지 별 파일 생성 및 내용 추가
- 각 화면별 필요한 라우팅 설정
- ui 반응형으로 변경(스크롤 안넘어가던 문제 해결)

## 📝 예외 처리

아직 페이지 별 url이  ex) "/recommend/detail/:walkwayId"으로 생성되어있어 해당 api연동 시 수정해야함-> `/recommend/detail/${walkwayId}`

## 💬 리뷰 요구사항(선택)

> 산책로 페이지별 (4종류) url 주소가 맘에 안들어요..
파일분리도 다시 해야할듯합니다..

## 📷화면 캡쳐

<img width="200px" src="https://github.com/user-attachments/assets/e72ad2b7-9f51-41a4-9ef1-592eac1d96e7"/>

<img width="200px" src="https://github.com/user-attachments/assets/853d6df8-8721-482c-a614-c1a667672832"/>

<img width="200px" src="https://github.com/user-attachments/assets/9fcb0cf4-5e26-449c-96ba-8305acf4593f"/>
<br/>
찜한 산책로는 북마크가 채워져있는 상태



