### PR TITLE
[DF-64]산책로 리뷰 내용보기 api 연동

### DIFF
--- a/src/apis/review.ts
+++ b/src/apis/review.ts
@@ -1,4 +1,8 @@
-import { ReviewRatingType, UserReviewsType } from "./review.type";
+import {
+  ReviewContentType,
+  ReviewRatingType,
+  UserReviewsType,
+} from "./review.type";
 import { ApiResponseFormat } from "./api.type";
 import instance from "./instance";
 
@@ -24,6 +28,23 @@ export const showReviewRating = async (
     const response = await instance.get<ApiResponseFormat<ReviewRatingType>>(
       `/walkways/${walkwayId}/review/rating`
     );
+    return response.data.data;
+  } catch (error) {
+    throw error;
+  }
+};
+
+// 산책로 리뷰 내용보기 api
+export const showReviewContent = async (
+  walkwayId: string,
+  type: string
+): Promise<{
+  reviews: ReviewContentType[];
+}> => {
+  try {
+    const response = await instance.get<
+      ApiResponseFormat<{ reviews: ReviewContentType[] }>
+    >(`/walkways/${walkwayId}/review/content?type=${type}`);
     return response.data.data;
   } catch (error) {
     throw error;

--- a/src/apis/review.type.ts
+++ b/src/apis/review.type.ts
@@ -18,3 +18,12 @@ export interface ReviewRatingType {
   two: number;
   one: number;
 }
+export interface ReviewContentType {
+  //산책로 리뷰 내용보기
+  reviewId: number;
+  nickname: string;
+  date: string;
+  period: string;
+  rating: number; //?
+  content: string;
+}

--- a/src/pages/review/ReviewCheck.tsx
+++ b/src/pages/review/ReviewCheck.tsx
@@ -25,6 +25,7 @@ const RatingsContainer = styled.div`
   flex-direction: row;
 `;
 const SortContainer = styled.div`
+  position: relative;
   display: flex;
   justify-content: flex-end;
   width: 100%;
@@ -44,21 +45,22 @@ const SortType = styled.div`
 const DropdownMenu = styled.div`
   position: absolute;
   top: 100%;
-  left: 0;
+  right: 0;
   background: white;
   border: 1px solid #ddd;
   border-radius: 4px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   z-index: 10;
-  width: 120px;
+  margin-top: 0.5rem;
+  width: 6.5rem;
 `;
 
 const DropdownItem = styled.div`
-  padding: 10px;
+  padding: 0.625rem;
   cursor: pointer;
-  &:hover {
-    background-color: #f0f0f0;
-  }
+  display: flex;
+  align-items: center;
+  justify-content: center;
 `;
 
 const RatingLeft = styled.div`
@@ -242,7 +244,6 @@ const ReviewCheck: React.FC = () => {
         <SortType
           onClick={() => {
             setIsDropdownOpen((prev) => !prev);
-            console.log("Dropdown 상태:", !isDropdownOpen);
           }}
         >
           {sortType === "rating" ? "별점순" : "최근순"}


### PR DESCRIPTION
## #️⃣ 이슈 번호

close:
- #DF-64

## 📝 작업 내용

- 산책로 리뷰 내용보기 api 연동
- type별 드롭다운 추가

<img width="200px" src="https://github.com/user-attachments/assets/e49279af-0f33-4e27-8fd9-9fe32f1133ca"/>
<img width="200px" src="https://github.com/user-attachments/assets/afb04957-0abf-4909-8a7e-5ee61b67f766"/>

## 수정사항
아 지금보니까 타입별 버튼 ui를 수정해야겠네용..
