### PR TITLE
[DF-71] 산책 경로 이미지화 및 폴리라인 지도 컴포넌트 구현

### DIFF
--- a/src/components/map/PathMap.tsx
+++ b/src/components/map/PathMap.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Map, Polyline } from 'react-kakao-maps-sdk';
+import styled from 'styled-components';
+
+const MapContainer = styled.div`
+  width: 80vw;
+  max-width: 322px;
+  height: 30vh;
+  max-height: 276px;
+  margin-bottom: 20px;
+`;
+
+interface PathMapProps {
+    pathCoords: [number, number][];
+  }
+  
+  const PathMap = ({ pathCoords }: PathMapProps) => {
+    const center = {
+      lat: pathCoords[0][0],
+      lng: pathCoords[0][1]
+    };
+  
+    const mapCoords = pathCoords.map(([lat, lng]) => ({ lat, lng }));
+  
+    return (
+      <MapContainer>
+        <Map
+          center={center}
+          style={{ width: '100%', height: '100%' }}
+          level={3}
+          draggable={true}
+        >
+          <Polyline
+            path={mapCoords}
+            strokeWeight={5}
+            strokeColor="#FF7575"
+            strokeOpacity={0.7}
+            strokeStyle="solid"
+          />
+        </Map>
+      </MapContainer>
+    );
+  };
+
+export default PathMap;

--- a/src/components/map/TrackingMap.tsx
+++ b/src/components/map/TrackingMap.tsx
@@ -42,15 +42,14 @@ export const TrackingMap = ({
     isTracking,
     onLocationUpdate,
     onDistanceUpdate
-}: TrackingMapProps) => {
+    }: TrackingMapProps) => {
     const [mapCenter, setMapCenter] = useState<Location>({ lat: 37.5665, lng: 126.9780 });
     const [userLocation, setUserLocation] = useState<Location | null>(null);
-    const [pathCoords, setPathCoords] = useState<Location[]>([]);
+    const [pathCoords, setPathCoords] = useState<number[][]>([]);
     const watchIdRef = useRef<number | null>(null);
 
-    // 거리 계산 (라이브러리 알아보깅ㄴ)
     const calculateDistance = (coord1: Location, coord2: Location): number => {
-        const R = 6371; // 지구의 반지름 (km)
+        const R = 6371;
         const dLat = (coord2.lat - coord1.lat) * Math.PI / 180;
         const dLon = (coord2.lng - coord1.lng) * Math.PI / 180;
         const a = 
@@ -69,18 +68,20 @@ export const TrackingMap = ({
                 lat: position.coords.latitude,
                 lng: position.coords.longitude
             };
+            const newCoord = [newLocation.lng, newLocation.lat];
 
             setUserLocation(newLocation);
             setMapCenter(newLocation);
             
             if (isTracking) {
                 setPathCoords(prev => {
-                    const newCoords = [...prev, newLocation];
-                    
-                    // 새로운 위치가 추가될 때마다 거리 계산
+                    const newCoords = [...prev, newCoord];
                     if (prev.length > 0) {
                         const lastCoord = prev[prev.length - 1];
-                        const newDistance = calculateDistance(lastCoord, newLocation);
+                        const newDistance = calculateDistance(
+                            {lat: lastCoord[1], lng: lastCoord[0]},
+                            newLocation
+                        );
                         onDistanceUpdate?.(newDistance);
                     }
                     
@@ -94,14 +95,12 @@ export const TrackingMap = ({
             console.error("사용자 위치 가져오기 에러:", error);
         };
 
-        // 초기 위치 가져오기
         navigator.geolocation.getCurrentPosition(successCallback, errorCallback, {
             enableHighAccuracy: true,
             maximumAge: 0,
             timeout: 5000
         });
 
-        // 트래킹 중일 때만 위치 감시 시작
         if (isTracking) {
             watchIdRef.current = navigator.geolocation.watchPosition(
                 successCallback,
@@ -144,7 +143,7 @@ export const TrackingMap = ({
                     {userLocation && <MapMarker position={userLocation} />}
                     {pathCoords.length > 1 && (
                         <Polyline
-                            path={pathCoords}
+                            path={pathCoords.map(coord => ({lat: coord[1], lng: coord[0]}))}
                             strokeWeight={5}
                             strokeColor="#FF7575"
                             strokeOpacity={0.7}

--- a/src/components/newway_register/DateDisplay.tsx
+++ b/src/components/newway_register/DateDisplay.tsx
@@ -1,24 +1,37 @@
-import { BiCalendarCheck, BiMapPin } from "react-icons/bi";
+import { BiCalendarCheck } from "react-icons/bi";
 import styled from "styled-components";
 import { theme } from "src/styles/colors/theme";
 
-const Date = styled.div`
-  color: ${theme.Green500};
-  font-weight: 600;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  @media (max-width: 375px) {
-    width: 300px;
-  }
+const DateContainer = styled.div`
+ color: ${theme.Green500};
+ font-weight: 600;
+ display: flex;
+ align-items: center; 
+ gap: 4px;
+ @media (max-width: 375px) {
+   width: 300px;
+ }
 `;
+
 export default function DateDisplay() {
-  return (
-    <Date>
-      <BiCalendarCheck
-        style={{ color: "black", width: "27px", height: "27px" }}
-      />
-      2024.09.26 오후 13:25
-    </Date>
-  );
+ const now = new Date(); 
+ 
+ const formatDate = () => {
+   const year = now.getFullYear();
+   const month = (now.getMonth() + 1).toString().padStart(2, '0');
+   const day = now.getDate().toString().padStart(2, '0');
+   const hours = now.getHours();
+   const minutes = now.getMinutes().toString().padStart(2, '0');
+   const ampm = hours >= 12 ? '오후' : '오전';
+   const displayHours = hours > 12 ? hours - 12 : hours;
+
+   return `${year}.${month}.${day} ${ampm} ${displayHours}:${minutes}`;
+ };
+
+ return (
+   <DateContainer>
+     <BiCalendarCheck style={{ color: "black", width: "27px", height: "27px" }} />
+     {formatDate()}
+   </DateContainer>
+ );
 }

--- a/src/pages/newway/index.tsx
+++ b/src/pages/newway/index.tsx
@@ -126,6 +126,13 @@ function NewWay() {
     if (timerIdRef.current) {
       clearInterval(timerIdRef.current);
     }
+    // 소주점 다섯째자리에서 끊기
+    const formattedCoords = pathCoordsRef.current.map((coord) => [
+      Number(coord.lng.toFixed(5)),
+      Number(coord.lat.toFixed(5)),
+    ]);
+
+    console.log("Path Coordinates:", formattedCoords);
 
     const pathData: PathData = {
       coordinates: pathCoordsRef.current,

--- a/src/pages/newway/index.tsx
+++ b/src/pages/newway/index.tsx
@@ -53,7 +53,7 @@ interface Location {
 }
 
 interface PathData {
-  coordinates: Location[];
+  coordinates: [number, number][]; 
   totalDistance: number;
   duration: string;
   startTime: Date;
@@ -122,20 +122,19 @@ function NewWay() {
 
   // 산책 중단 확인
   const handleStopWalk = () => {
-    // 타이머 정지
     if (timerIdRef.current) {
       clearInterval(timerIdRef.current);
     }
-    // 소주점 다섯째자리에서 끊기
-    const formattedCoords = pathCoordsRef.current.map((coord) => [
-      Number(coord.lng.toFixed(5)),
+  
+    const formattedCoords: [number, number][] = pathCoordsRef.current.map((coord) => [
       Number(coord.lat.toFixed(5)),
+      Number(coord.lng.toFixed(5))
     ]);
 
     console.log("Path Coordinates:", formattedCoords);
 
     const pathData: PathData = {
-      coordinates: pathCoordsRef.current,
+      coordinates: formattedCoords,
       totalDistance: distance,
       duration: duration,
       startTime: new Date(startTimeRef.current!),

--- a/src/utils/drawPathUtils.ts
+++ b/src/utils/drawPathUtils.ts
@@ -1,0 +1,42 @@
+export const drawPath = (coordinates: [number, number][]): Promise<string> => {
+    const CANVAS_SIZE = 480;
+    const CANVAS_OFFSET = CANVAS_SIZE * 0.2;
+    
+    const lats = coordinates.map(([lat]) => lat);
+    const lngs = coordinates.map(([, lng]) => lng);
+    
+    const minLat = Math.min(...lats);
+    const maxLat = Math.max(...lats);
+    const minLng = Math.min(...lngs);
+    const maxLng = Math.max(...lngs);
+  
+    const canvas = document.createElement('canvas');
+    canvas.width = CANVAS_SIZE;
+    canvas.height = CANVAS_SIZE;
+    const ctx = canvas.getContext('2d');
+    
+    if (!ctx) throw new Error('Canvas context not available');
+  
+    const scaleX = (canvas.width - CANVAS_OFFSET * 2) / (maxLng - minLng);
+    const scaleY = (canvas.height - CANVAS_OFFSET * 1.5) / (maxLat - minLat);
+  
+    ctx.strokeStyle = '#FF7575';
+    ctx.lineWidth = 5;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+  
+    ctx.beginPath();
+    coordinates.forEach(([lat, lng], i) => {
+      const x = CANVAS_OFFSET + (lng - minLng) * scaleX;
+      const y = canvas.height - CANVAS_OFFSET - (lat - minLat) * scaleY;
+      
+      if (i === 0) {
+        ctx.moveTo(x, y);
+      } else {
+        ctx.lineTo(x, y);
+      }
+    });
+    ctx.stroke();
+  
+    return Promise.resolve(canvas.toDataURL());
+  };


### PR DESCRIPTION
## #️⃣ 이슈 번호

close:
- #DF-72

## 📝 작업 내용
- `pathCoords`를 geoJson 형식으로 변경하고 소수 다섯째자리에서 반올림
- 산책로 등록 페이지에서 현재 시간을 포맷팅하여 표시하도록 `DateDisplay` 컴포넌트 수정 (년.월.일 오전/오후 시:분 형식으로 표시)
- `canvasAPI`를 사용하여 산책 경로 배열을 이미지화 유틸 함수 구현
- 경로 배열로 폴리라인을 그린 카카오맵 컴포넌트 구현

## 📝 참고 자료
https://velog.io/@world_wide_woody/%EC%82%B0%EC%B1%85-%EA%B2%BD%EB%A1%9C%EB%A5%BC-%EC%9D%B4%EB%AF%B8%EC%A7%80%EB%A1%9C-%EC%A0%80%EC%9E%A5%ED%95%98%EA%B8%B0-509fgjl8

https://jaewoong.dev/entry/%EC%9C%A0%EC%A0%80%EC%9D%98-%EC%82%B0%EC%B1%85%EA%B2%BD%EB%A1%9C%EB%A5%BC-%EC%8D%B8%EB%84%A4%EC%9D%BC%EB%A1%9C-%EC%A0%80%EC%9E%A5%ED%95%98%EA%B8%B0

## 📸 캡쳐 
📝 리뷰어 참고 사항 : 경로 좌표 배열 목데이터를 따로 만들어, 산책을 하지 않아도 이미지와 지도가 잘 그려지는지 테스트하기 위해 테스트용 상태 버튼을 따로 만들고 jsx에서 분기처리를 하여 렌더링했습니다. 테스트 on/off 버튼으로 확인하면 됩니다! 

<img width="200" alt="스크린샷 2025-01-25 02 40 36" src="https://github.com/user-attachments/assets/47f9a45f-e4fd-4f20-9fff-3d0197052e98" />
<img width="200" alt="스크린샷 2025-01-25 02 40 44" src="https://github.com/user-attachments/assets/d13a6113-417b-4005-b4e8-577c6a99afaa" />
<img width="200" alt="스크린샷 2025-01-25 02 40 54" src="https://github.com/user-attachments/assets/90ae9ae4-b677-412a-bdf8-353304ae6f04" />

