### PR TITLE
[DF-85] 토큰 갱신 상태 관리 추가

### DIFF
--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -5,7 +5,7 @@ import { ReactComponent as BookMark } from "../../assets/svg/BookMark.svg";
 import TrailCard from "src/components/TrailCard_mp";
 import ReviewCard from "src/components/ReviewCard_mp";
 import { Link, useNavigate } from "react-router-dom";
-import profileImg from "../../assets/svg/profile.svg";
+import profileImg from "../../assets/images/profile.png";
 import TrailBookmark from "../mypage/TrailBookmark";
 import { getUserProfile } from "../../apis/auth";
 import { UserProfileType } from "../../apis/auth.type";
@@ -13,6 +13,9 @@ import BottomNavigation from "src/components/bottomNavigation";
 import AppBar from "src/components/appBar";
 import { getMyWalkways } from "src/apis/walkway";
 import { Trail } from "src/apis/walkway.type";
+import instance from "src/apis/instance";
+import { theme } from "src/styles/colors/theme";
+import { useToast } from "src/hooks/useToast";
 
 const Wrapper = styled.div`
   display: flex;
@@ -32,27 +35,53 @@ const Line = styled.div`
   background-color: #cdcdcd;
   margin: 12px;
 `;
-//프로필부분
+
 const Profile = styled.div`
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
+  width: 100%;
+  padding: 10px;
+`;
+
+const ProfileTop = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  width: 100%;
+  gap: 20px;
+`;
+
+const ProfileInfo = styled.div`
+  display: flex;
   align-items: center;
+  gap: 15px;
 `;
 
 const Name = styled.div`
-  font-size: 20px;
+  font-size: 24px;
   font-weight: bold;
   color: #054630;
-  margin: 5px;
 `;
 
 const Img = styled.img`
-  width: 95px;
-  height: 95px;
-  border-radius: 50px;
-  border: black 0.5px solid;
-  margin: 15px;
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  border: 4px solid ${theme.White};
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
   object-fit: cover;
+`;
+
+const LogoutButton = styled.button`
+  padding: 6px;
+  background-color: ${theme.White};
+  color: ${theme.Green500};
+  border: 1px solid ${theme.Green700};
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
 `;
 
 //내가 등록한 산책로
@@ -61,6 +90,7 @@ const SeeAll = styled.div`
   flex-direction: row;
   justify-content: space-between;
 `;
+
 const Title = styled.div`
   font-size: 15px;
   font-weight: 700;
@@ -71,6 +101,7 @@ const Button = styled.span`
   font-size: 10px;
   margin: 10px 25px;
 `;
+
 const Items = styled.div`
   display: flex;
   overflow-x: auto;
@@ -129,6 +160,7 @@ const reviews: Review[] = [
 
 function MyPage() {
   const navigate = useNavigate();
+  const { showToast } = useToast();
 
   const [userProfile, setUserProfile] = useState<UserProfileType | null>(null);
   const [previewTrails, setPreviewTrails] = useState<Trail[]>([]);
@@ -164,11 +196,21 @@ function MyPage() {
         //프리뷰를 클릭해서 단건 조회 페이지로 이동했을 시,
         //단건 조회 페이지에서 백버튼 네이게이션은 다시 마이페이지로
         //하기 위해서 state 전달
-        state: { from: 'mypage' }
+        state: { from: "mypage" },
       });
     },
     [navigate]
   );
+
+  const handleLogout = async () => {
+    try {
+      await instance.delete("/auth/logout");
+      showToast("로그아웃되었습니다!", "success");
+      navigate("/signin");
+    } catch (error) {
+      showToast("로그아웃 중 문제가 발생했습니다.", "error");
+    }
+  };
 
   if (isLoading) return <div>로딩중...</div>;
   if (error) return <div>{error}</div>;
@@ -178,14 +220,19 @@ function MyPage() {
       <AppBar onBack={() => navigate("/")} title="마이 페이지" />
       <Wrapper>
         <Profile>
-          <Img
-            src={userProfile?.profileImageUrl || profileImg}
-            alt="프로필 이미지"
-          />
-          <div>
-            <Name>{userProfile?.nickname || "이름"}</Name>
-            <div>{userProfile?.email || "이메일 정보 없음"}</div>
-          </div>
+          <ProfileTop>
+            <ProfileInfo>
+              <Img
+                src={userProfile?.profileImageUrl || profileImg}
+                alt="프로필 이미지"
+              />
+              <div>
+                <Name>{userProfile?.nickname || "이름"}</Name>
+                <div>{userProfile?.email || "이메일 정보 없음"}</div>
+              </div>
+            </ProfileInfo>
+            <LogoutButton onClick={handleLogout}>로그아웃</LogoutButton>
+          </ProfileTop>
         </Profile>
         <Line />
         <div>
@@ -197,7 +244,11 @@ function MyPage() {
           </SeeAll>
           <Items>
             {previewTrails.map((trail) => (
-              <TrailCard key={trail.walkwayId} trail={trail} onClick={handleCardClick} />
+              <TrailCard
+                key={trail.walkwayId}
+                trail={trail}
+                onClick={handleCardClick}
+              />
             ))}
           </Items>
         </div>


### PR DESCRIPTION
## #️⃣ 이슈 번호

close:
- #DF-85

## 📝 작업 내용
- Refresh 토큰 로직 개선
  - 동시에 여러 요청이 401 에러를 받았을 때 토큰 갱신은 한 번만 수행되도록 개선
  - 대기중인 요청들을 subscribers 배열에 저장하여 관리, 새 토큰 발급 시 일괄 처리
  - refresh 토큰 API 요청 실패(에러코드: AUTH-005) 시 세션 만료 처리
- 마이페이지 > 로그아웃 버튼 추가, api 연결


## 캡쳐
<img width="200" alt="스크린샷 2025-02-08 21 04 19" src="https://github.com/user-attachments/assets/e6569ee2-544d-478d-b34a-de89993ff21d" />
