### PR TITLE
[DF-89] 거리 측정 로직 수정(m, km)

### DIFF
--- a/src/components/newway_register/TrailInfo.tsx
+++ b/src/components/newway_register/TrailInfo.tsx
@@ -2,11 +2,6 @@ import { BiMapPin } from "react-icons/bi";
 import { BsClock } from "react-icons/bs";
 import styled from "styled-components";
 
-interface TrailInfoProps {
-  duration: number; // 초 단위
-  distance: number; // km 단위 (소수)
-}
-
 const TrailInfoContainer = styled.div`
   display: flex;
   flex-direction: row;
@@ -47,19 +42,44 @@ const DistanceItems = styled.div`
   }
 `;
 
-export default function TrailInfo({ duration, distance }: TrailInfoProps) {
-  // 초를 "MM:SS" 형식으로 변환
+interface TrailInfoProps {
+  duration: number;
+  distance: number;  // NewWay에서는 미터 단위, Registration에서는 km 단위로 받음
+  isRegistration?: boolean;  // Registration 페이지인지 여부
+}
+
+
+export default function TrailInfo({ duration, distance, isRegistration = false }: TrailInfoProps) {
   const formatDuration = (seconds: number): string => {
     const minutes = Math.floor(seconds / 60);
     const remainingSeconds = Math.floor(seconds % 60);
-    return `${String(minutes).padStart(2, "0")}:${String(
-      remainingSeconds
-    ).padStart(2, "0")}`;
+    return `${String(minutes).padStart(2, "0")}:${String(remainingSeconds).padStart(2, "0")}`;
   };
 
-  const formatDistance = (km: number): string => {
-    return km.toFixed(2);
+  const formatDistance = (value: number, isRegistration: boolean): { value: string; unit: string } => {
+    if (isRegistration) {
+      // Registration 페이지에서는 항상 km로 표시 (소수점 2자리)
+      return {
+        value: value.toFixed(2),
+        unit: "km"
+      };
+    } else {
+      // NewWay 페이지에서는 동적으로 단위 변환 (미터 단위로 받음)
+      if (value >= 1000) {
+        // 1km 이상일 때도 소수점 2자리까지만 표시
+        return {
+          value: (value / 1000).toFixed(2),
+          unit: "km"
+        };
+      }
+      return {
+        value: Math.round(value).toString(),
+        unit: "m"
+      };
+    }
   };
+
+  const formattedDistance = formatDistance(distance, isRegistration);
 
   return (
     <TrailInfoContainer>
@@ -70,14 +90,9 @@ export default function TrailInfo({ duration, distance }: TrailInfoProps) {
 
       <DistanceItems>
         <BiMapPin style={{ width: "24px", height: "24px" }} />
-        {formatDistance(distance)}
-        <span
-          style={{
-            fontSize: "18px",
-            fontFamily: "Pretendard",
-          }}
-        >
-          km
+        {formattedDistance.value}
+        <span style={{ fontSize: "18px", fontFamily: "Pretendard" }}>
+          {formattedDistance.unit}
         </span>
       </DistanceItems>
     </TrailInfoContainer>

--- a/src/pages/newway/index.tsx
+++ b/src/pages/newway/index.tsx
@@ -205,13 +205,16 @@ export default function NewWay() {
           });
 
           const courseImageId = await uploadCourseImage(courseImageFile);
+          
+          // 미터를 킬로미터로 변환하고 소수점 2자리까지 반올림
+          const distanceInKm = Number((distances / 1000).toFixed(2));
+          console.log('산책시간, 산책거리:', elapsedTime, distanceInKm);
 
           const pathData: PathData = {
             coordinates: movingPath,
-            totalDistance: distances,
+            totalDistance: distanceInKm,  // km 단위로 변환하여 저장
             duration: elapsedTime,
-            startTime:
-              startTimeRef.current || new Date(Date.now() - elapsedTime * 1000),
+            startTime: startTimeRef.current || new Date(Date.now() - elapsedTime * 1000),
             endTime: new Date(),
             pathImage: pathImage,
             courseImageId: courseImageId,
@@ -226,10 +229,15 @@ export default function NewWay() {
         }
       } else {
         try {
+          // 미터를 킬로미터로 변환하고 소수점 2자리까지 반올림
+          const distanceInKm = Number((distances / 1000).toFixed(2));
+          console.log('이용시간, 이용거리:', elapsedTime, distanceInKm);
+          
           const historyResponse = await createWalkwayHistory(walkwayId, {
             time: elapsedTime,
-            distance: distances,
+            distance: distanceInKm,  // km 단위로 전송
           });
+          
           showToast("산책로를 이용해주셔서 감사합니다!", "success");
           navigate(`/main/recommend/detail/${walkwayId}`, {
             state: {
@@ -242,12 +250,6 @@ export default function NewWay() {
           showToast("산책로 이용 기록 저장에 실패했습니다.", "error");
           navigate(-1);
         }
-      }
-    } else if (modalType === "back") {
-      if (mode === "create") {
-        navigate("/main");
-      } else {
-        navigate(-1); // follow 모드일 때는 이전 페이지로
       }
     }
     setModalType(null);
@@ -340,10 +342,12 @@ export default function NewWay() {
         title={mode === "create" ? "산책로 등록" : "산책로 따라걷기"}
       />
       <Container>
-        <InfoContainer>
-          <TrailInfo duration={elapsedTime} distance={distances / 1000} />
+      <InfoContainer>
+          <TrailInfo 
+            duration={elapsedTime} 
+            distance={distances}  // 미터나 키로미터 단위
+          />
         </InfoContainer>
-
         <TrackingMap
           userLocation={userLocation}
           movingPath={movingPath}

--- a/src/pages/newway/registration.tsx
+++ b/src/pages/newway/registration.tsx
@@ -287,7 +287,8 @@ export default function Registration() {
           </Content>
           <TrailInfo
             duration={pathData.duration}
-            distance={pathData.totalDistance}
+            distance={pathData.totalDistance}  // 여기서는 이미 km 단위로 받은 값을 그대로 전달함
+            isRegistration={true}
           />
         </ContentWrapper>
         <PathMapContainer>

--- a/src/utils/calculateDistance.ts
+++ b/src/utils/calculateDistance.ts
@@ -22,10 +22,10 @@ export function calculateDistance(movingPath: Location[]): number {
         Math.sin(dLng / 2) *
         Math.sin(dLng / 2);
     let c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-    let distance = R * c; // 거리 (km)
-
-    // 소수점 2자리까지만 반환
-    return parseFloat(distance.toFixed(2));
+    let distanceKm = R * c; // 거리 (km)
+    
+    // 미터 단위로 변환하여 반환
+    return Math.round(distanceKm * 1000);
   }
   return 0;
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

close:
- #DF-89

## 📝 작업 내용
- 산책 거리가 실시간으로 표시되지 않는 에러 해결 (테스트 필요함, 선배포 후 테스트 예정)
- 산책 측정 거리 표시 단위 개선
- 실시간 산책/이용 중 거리 표시를 상황에 맞게 변경
- 500m 이상 걸은 경우에만 등록이 가능하도록 기획이 변경됨에 따라 m단위 보이도록 수정
  - 1km 미만: m 단위로 표시
  - 1km 이상: km 단위로 표시 (소수점 2자리)
- Registration 페이지에서는 항상 km 단위로 표시 (소수점 2자리)
- 서버 전송 시 km 단위로 변환하여 전송 (소수점 2자리)