### PR TITLE
[DF-90] 산책로 검색, 내가 등록한 산책로 페이지네이션 lastId 로직 개선

### DIFF
--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -125,6 +125,7 @@ function Main() {
     try {
       setLoading(true);
       setError(null);
+      console.log("🔍 산책로 요청 시 lastId:", reset ? null : lastId);
 
       const response = await searchWalkways({
         sort,
@@ -139,11 +140,14 @@ function Main() {
         reset ? response.walkways : [...prev, ...response.walkways]
       );
       setHasMore(response.hasNext);
+
       if (response.walkways.length > 0) {
-        setLastId(response.walkways[response.walkways.length - 1]?.walkwayId);
+        const newLastId =
+          response.walkways[response.walkways.length - 1]?.walkwayId;
+        console.log("📌 응답에서 추출한 새로운 lastId:", newLastId);
+        setLastId(newLastId);
       }
 
-      // 좋아요 상태 초기화
       if (reset) {
         const newLikedPaths = Object.fromEntries(
           response.walkways.map((walkway) => [
@@ -267,14 +271,16 @@ function Main() {
   const handleScroll = (event: React.UIEvent<HTMLDivElement>) => {
     const { scrollTop, clientHeight, scrollHeight } = event.currentTarget;
     if (scrollHeight - scrollTop <= clientHeight * 1.5 && hasMore && !loading) {
-      fetchWalkways(
-        selectedLocation!.latitude,
-        selectedLocation!.longitude,
-        sortOption
-      );
+      console.log("👀 스크롤이 하단에 도달했을 때의 lastId:", lastId);
+      if (selectedLocation) {
+        fetchWalkways(
+          selectedLocation.latitude,
+          selectedLocation.longitude,
+          sortOption
+        );
+      }
     }
   };
-
   /**
    * 좋아요 클릭 처리
    */


### PR DESCRIPTION
## #️⃣ 이슈 번호

close:
- #DF-90

## 📝 작업 내용
- 산책로 조회 시 lastId 추출 및 전송 로직 개선
- Main과 TrailListPage에 lastId 디버깅용 로그 추가

<img width="400" alt="스크린샷 2025-02-12 01 59 01" src="https://github.com/user-attachments/assets/a223976d-6499-481d-9c43-ebf043746fe0" />
<img width="350" alt="스크린샷 2025-02-12 02 03 01" src="https://github.com/user-attachments/assets/fc171b48-9b1a-45b4-81c8-5e2146238299" />
