### PR TITLE
[DF-92] [QA] 산책 종료 과정 개선과 모달 디자인 업데이트

### DIFF
--- a/src/components/modal/ConfirmationModal.tsx
+++ b/src/components/modal/ConfirmationModal.tsx
@@ -1,7 +1,8 @@
-import styled from 'styled-components';
-import Modal from './Modal'
+import styled from "styled-components";
+import Modal from "./Modal";
 import { theme } from "src/styles/colors/theme";
-import { ReactNode } from 'react';
+import { ReactNode } from "react";
+import { MdWarning, MdCheckCircle, MdInfoOutline, MdDirectionsWalk } from "react-icons/md";
 
 interface ConfirmationModalProps {
   isOpen: boolean;
@@ -10,46 +11,145 @@ interface ConfirmationModalProps {
   message: ReactNode;
   cancelText?: string;
   confirmText?: string;
+  modalType?: "stop" | "done" | "back" | "default";
+  mode?: "create" | "follow";
 }
+
+const ModalContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+  `;
+
+const IconContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-bottom: 6px;
+`;
+
+const TitleText = styled.h3`
+  text-align: center;
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin: 0;
+  color: ${theme.Gray900};
+`;
 
 const ModalText = styled.p`
   text-align: center;
-  font-size: 1.1rem;
+  font-size: 1rem;
+  line-height: 1.5;
   white-space: pre-line;
+  margin: 0;
+  color: ${theme.Gray700};
+  max-width: 280px;
+`;
+
+const TextContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 8px;
 `;
 
 const ButtonContainer = styled.div`
   display: flex;
   justify-content: center;
-  gap: 20px;
+  gap: 16px;
+  width: 100%;
+  margin-top: 8px;
 `;
 
 const Button = styled.button<{ isConfirm?: boolean }>`
-  padding: 12px 30px;
-  border-radius: 15px;
+  padding: 12px 24px;
+  border-radius: 12px;
   border: none;
-  background-color: ${props => props.isConfirm ? theme.Green500 : theme.Gray400};
-  color: ${theme.White};
+  font-weight: 500;
+  font-size: 0.95rem;
+  background-color: ${(props) =>
+    props.isConfirm ? theme.Green500 : theme.Gray200};
+  color: ${(props) => (props.isConfirm ? theme.White : theme.Gray700)};
   cursor: pointer;
+  transition: all 0.2s ease;
+  flex: 1;
+  max-width: 130px;
+
+  &:hover {
+    background-color: ${(props) =>
+      props.isConfirm ? theme.Green600 : theme.Gray300};
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
 `;
 
-const ConfirmationModal = ({ 
-  isOpen, 
-  onClose, 
-  onConfirm, 
+const ConfirmationModal = ({
+  isOpen,
+  onClose,
+  onConfirm,
   message,
   cancelText = "취소",
-  confirmText = "확인"
+  confirmText = "확인",
+  modalType = "default",
+  mode = "create",
 }: ConfirmationModalProps) => {
+  const getModalContent = () => {
+    switch (modalType) {
+      case "stop":
+        return {
+          icon: <MdWarning size={52} color={theme.Red} />,
+          title: "산책 조건 미달",
+          iconColor: theme.Red,
+        };
+      case "done":
+        if (mode === "create") {
+          return {
+            icon: <MdCheckCircle size={52} color={theme.Green500} />,
+            title: "산책로 등록",
+            iconColor: theme.Green500,
+          };
+        } else {
+          return {
+            icon: <MdDirectionsWalk size={52} color={theme.Following} />,
+            title: "이용 완료",
+            iconColor: theme.Following,
+          };
+        }
+      case "back":
+        return {
+          icon: <MdInfoOutline size={52} color={theme.Following} />,
+          iconColor: theme.Following,
+        };
+      default:
+        return {
+          icon: <MdInfoOutline size={52} color={theme.Following} />,
+          title: "알림",
+          iconColor: theme.Following,
+        };
+    }
+  };
+
+  const { icon, title } = getModalContent();
+
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
-      <div style={{display: 'flex', flexDirection: 'column', gap: 30}}>
-      <ModalText>{message}</ModalText>
-      <ButtonContainer>
-        <Button onClick={onClose}>{cancelText}</Button>
-        <Button isConfirm onClick={onConfirm}>{confirmText}</Button>
-      </ButtonContainer>
-      </div>
+      <ModalContent>
+        <IconContainer>{icon}</IconContainer>
+
+        <TextContainer>
+          {title && <TitleText>{title}</TitleText>}
+          <ModalText>{message}</ModalText>
+        </TextContainer>
+
+        <ButtonContainer>
+          <Button onClick={onClose}>{cancelText}</Button>
+          <Button isConfirm onClick={onConfirm}>
+            {confirmText}
+          </Button>
+        </ButtonContainer>
+      </ModalContent>
     </Modal>
   );
 };


### PR DESCRIPTION
## #️⃣ 이슈 번호

close:
- #DF-92

## 📝 작업 내용
### QA 문제 상황
https://www.notion.so/1a4ea8d4d14380499f7fcaf3b06e74dc?pvs=4
- “산책 중단” → “산책 완료”가 더 적절해 보이고,
- 현재는 “10분 이상 ~”이라는 문구가 나오고 산책 중단이 안되는데, “10분 이상 ~ “이라는 문구와 “산책을 중단 하시겠습니까?”라는 버튼과 함께 산책 중단을 누르면 아예 산책로에 새롭게 등록이 안되는 걸로 변경하는게 더 좋아보입니다.

### 수정 내용
- 모달 디자인을 개선하고 각 상황에 맞는 아이콘과 타이틀 추가
- 모달 텍스트와 버튼 레이아웃을 가독성 있게 변경
- "10분 이상, 200m 이상 산책하지 않은 경우, 산책 정보가 저장되지 않습니다" 메시지와 함께 토스트 대신 모달 표시
- 조건 미달 시 "홈으로" 버튼을 눌러 메인 화면으로 이동할 수 있도록 기능 추가
- "create" 모드와 "follow(이용하기)" 모드에 맞는 각각의 모달 타입과 내용 구현
- 버튼 텍스트를 작업에 맞게 수정 ("등록하기", "완료하기", "계속 산책하기" 등)

## 📝 캡쳐
산책 시작, 산책 완료, 이용 완료 버튼 클릭 시
<p float="left">
  <img width="200" alt="스크린샷 2025-02-24 23 49 11" src="https://github.com/user-attachments/assets/54f2a03d-2e06-42f6-b3bd-c0d2afb2d296" />
  <img width="200" alt="스크린샷 2025-02-25 00 03 39" src="https://github.com/user-attachments/assets/38ce13a1-5300-4563-964b-a0c83edd3df6" />
  <img width="200" alt="스크린샷 2025-02-24 23 52 09" src="https://github.com/user-attachments/assets/5d812b1d-1abb-4ffc-8c90-3da313274004" />
</p>
백버튼 클릭 시
<p float="left">
  <img width="200" alt="스크린샷 2025-02-24 23 49 21" src="https://github.com/user-attachments/assets/d431cc78-b43d-4992-99c6-d59531544d94" />
  <img width="200" alt="스크린샷 2025-02-25 00 03 51" src="https://github.com/user-attachments/assets/23ae1dfc-eae7-49e0-9b68-d2c847dedc77" />
</p>