### PR TITLE
[DF-93] API 성공시 기본 응답 포맷 삭제, 응답 데이터 구조 변경

### DIFF
--- a/src/apis/api.type.ts
+++ b/src/apis/api.type.ts
@@ -1,10 +1,3 @@
-export interface ApiResponseFormat<T> {
-  data: T;
-  status: number;
-  message?: string;
-  isSuccess: boolean;
-}
-
 export interface ApiErrorResponse {
   isSuccess: false;
   code: string;

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,31 +1,14 @@
-import { setCookie } from "src/utils/cookieUtils";
-import { ApiResponseFormat } from "./api.type";
-import { AuthResponse, UserProfileType } from "./auth.type";
+import { UserProfileType } from "./auth.type";
 import instance from "./instance";
 
 //유저 프로필 조회 api
 export const getUserProfile = async (): Promise<UserProfileType> => {
   try {
-    const response = await instance.get<ApiResponseFormat<UserProfileType>>(
+    const response = await instance.get<UserProfileType>(
       '/users/profile'
     );
-    return response.data.data;
+    return response.data;
   } catch (error) {
     throw error;
   }
-};
-
-//리프레시
-export const refreshTokens = async (refreshToken: string): Promise<boolean> => {
-  const response = await instance.post<ApiResponseFormat<AuthResponse>>(
-    "/auth/refresh",
-    { refreshToken }
-  );
-  if (response.data.isSuccess) {
-    const { accessToken, refreshToken: newRefreshToken } = response.data.data;
-    setCookie("accessToken", accessToken);
-    setCookie("refreshToken", newRefreshToken);
-    return true;
-  }
-  return false;
 };

--- a/src/apis/auth.type.ts
+++ b/src/apis/auth.type.ts
@@ -1,8 +1,3 @@
-export interface AuthResponse {
-  accessToken: string;
-  refreshToken: string;
-}
-
 // 마이페이지 유저 프로필 타입
 export interface UserProfileType {
   profileImageUrl: string;

--- a/src/apis/bookmark.ts
+++ b/src/apis/bookmark.ts
@@ -1,4 +1,3 @@
-import { ApiResponseFormat } from "./api.type";
 import {
   AddBookmarkRequest,
   AddBookmarkResponse,
@@ -11,10 +10,10 @@ export const AddToBookmark = async (
   params: AddBookmarkRequest
 ): Promise<AddBookmarkResponse> => {
   try {
-    const response = await instance.post<
-      ApiResponseFormat<AddBookmarkResponse>
-    >(`/bookmarks`, params);
-    return response.data.data;
+    const response = await instance.post
+      <AddBookmarkResponse>
+    (`/bookmarks`, params);
+    return response.data;
   } catch (error) {
     throw error;
   }
@@ -29,11 +28,11 @@ export const SaveToBookmark = async ({
   walkwayId: number;
 }): Promise<addToBookmark> => {
   try {
-    const response = await instance.post<ApiResponseFormat<addToBookmark>>(
+    const response = await instance.post<addToBookmark>(
       `/bookmarks/${bookmarkId}/walkways`,
       { walkwayId }
     );
-    return response.data.data;
+    return response.data;
   } catch (error) {
     throw error;
   }
@@ -48,7 +47,7 @@ export const RemoveToBookmark = async ({
   walkwayId: number;
 }): Promise<{}> => {
   try {
-    const response = await instance.delete<ApiResponseFormat<{}>>(
+    const response = await instance.delete(
       `/bookmarks/${bookmarkId}/walkways/${walkwayId}`
     );
     return response;

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -15,14 +15,15 @@ export const instance = axios.create({
 instance.interceptors.response.use(
   (response: AxiosResponse) => response,
   async (error: AxiosError) => {
-    const errorData = error.response?.data as ApiErrorResponse;
+    if (error.response) {
+    const errorData = error.response.data as ApiErrorResponse;
     if (errorData?.code === "AUTH-01") {
       window.location.href = "/signin";
-      return Promise.reject(error);
     }
 
     return Promise.reject(error);
   }
+}
 );
 
 export default instance;

--- a/src/apis/likedWalkway.ts
+++ b/src/apis/likedWalkway.ts
@@ -1,4 +1,3 @@
-import { ApiResponseFormat } from "./api.type";
 import instance from "./instance";
 import { likedWalkwayType } from "./likedWalkway.type";
 
@@ -10,10 +9,10 @@ export const toggleLike = async ({
 }): Promise<{}> => {
   try {
     const response = isLiked //하트에 따라 처리
-      ? await instance.delete<ApiResponseFormat<{}>>( //산책로 좋아요 취소 api
+      ? await instance.delete( //산책로 좋아요 취소 api
           `/walkways/${walkwayId}/likes`
         )
-      : await instance.post<ApiResponseFormat<{}>>( //산책로 좋아요 선택 api
+      : await instance.post( //산책로 좋아요 선택 api
           `/walkways/${walkwayId}/likes`
         );
     return response;

--- a/src/apis/review.ts
+++ b/src/apis/review.ts
@@ -6,7 +6,6 @@ import {
   walkwayHistoryType,
   WriteReviewType,
 } from "./review.type";
-import { ApiResponseFormat } from "./api.type";
 import instance from "./instance";
 
 // 작성한 리뷰 전체보기 api
@@ -17,16 +16,16 @@ export const getUserReviews = async ({
   size: number;
   lastId?: number;
 }): Promise<{
-  reviews: UserReviewsType[];
+  data: UserReviewsType[];
   hasNext: boolean;
 }> => {
   try {
-    const response = await instance.get<
-      ApiResponseFormat<{ reviews: UserReviewsType[]; hasNext: boolean }>
-    >("/users/reviews", {
+    const response = await instance.get
+      <{ data: UserReviewsType[]; hasNext: boolean }>
+    ("/users/reviews", {
       params: { size, lastId },
     });
-    return response.data.data;
+    return response.data;
   } catch (error) {
     throw error;
   }
@@ -37,10 +36,10 @@ export const showReviewRating = async (
   walkwayId: string
 ): Promise<ReviewRatingType> => {
   try {
-    const response = await instance.get<ApiResponseFormat<ReviewRatingType>>(
+    const response = await instance.get<ReviewRatingType>(
       `/walkways/${walkwayId}/review/rating`
     );
-    return response.data.data;
+    return response.data;
   } catch (error) {
     throw error;
   }
@@ -54,10 +53,10 @@ export const showReviewContent = async (
   reviews: ReviewContentType[];
 }> => {
   try {
-    const response = await instance.get<
-      ApiResponseFormat<{ reviews: ReviewContentType[] }>
+    const response = await instance.get
+    <{ reviews: ReviewContentType[] }
     >(`/walkways/${walkwayId}/review/content?sort=${sort}`);
-    return response.data.data;
+    return response.data;
   } catch (error) {
     throw error;
   }
@@ -85,10 +84,10 @@ export const writeableReviewRecord = async (
   walkwayId: number
 ): Promise<walkwayHistoryType[]> => {
   try {
-    const { data } = await instance.get<{ data: walkwayHistoryResponse }>(
+    const response = await instance.get<{ data: walkwayHistoryResponse }>(
       `/walkways/${walkwayId}/history`
     );
-    return data.data.walkwayHistories ?? [];
+    return response.data.data.data;
   } catch (error) {
     throw error;
   }
@@ -102,17 +101,15 @@ export const getReviewRecord = async ({
   size: number;
   lastId?: number;
 }): Promise<{
-  walkwayHistories: walkwayHistoryType[];
+  data: walkwayHistoryType[];
 }> => {
   try {
-    const response = await instance.get<
-      ApiResponseFormat<{
-        walkwayHistories: walkwayHistoryType[];
-      }>
-    >("/users/walkways/history", {
+    const response = await instance.get<{
+      data: walkwayHistoryType[];
+    }>("/users/walkways/history", {
       params: { size, lastId },
     });
-    return response.data.data;
+    return response.data;
   } catch (error) {
     throw error;
   }

--- a/src/apis/review.type.ts
+++ b/src/apis/review.type.ts
@@ -52,5 +52,5 @@ export interface walkwayHistoryType {
 }
 
 export interface walkwayHistoryResponse {
-  walkwayHistories: walkwayHistoryType[];
+  data: walkwayHistoryType[];
 }

--- a/src/apis/walkway.ts
+++ b/src/apis/walkway.ts
@@ -1,16 +1,15 @@
 import instance from "src/apis/instance";
 import {
   WalkwayParams,
-  WalkwaysApiResponse,
-  WalkwayDetailResponse,
   CreateWalkwayType,
   UpdateWalkwayType,
   MyWalkwaysResponse,
-  MyWalkwaysApiResponse,
   FetchWalkwaysOptions,
   WalkwayHistoryResponse,
+  WalkwaysResponse,
+  WalkwayDetail,
 } from "./walkway.type";
-import { ApiErrorResponse, ApiResponseFormat } from "src/apis/api.type";
+import { ApiErrorResponse } from "src/apis/api.type";
 import { AxiosError } from "axios";
 
 /**
@@ -18,7 +17,7 @@ import { AxiosError } from "axios";
  */
 export const searchWalkways = async (params: WalkwayParams) => {
   try {
-    const { data: response } = await instance.get<WalkwaysApiResponse>(
+    const { data: response } = await instance.get<WalkwaysResponse>(
       "/walkways",
       {
         params: {
@@ -32,11 +31,7 @@ export const searchWalkways = async (params: WalkwayParams) => {
       }
     );
 
-    if (!response.isSuccess) {
-      throw new Error(response.message);
-    }
-
-    return response.data;
+    return response;
   } catch (error) {
     const axiosError = error as AxiosError<ApiErrorResponse>;
     throw new Error(
@@ -50,15 +45,11 @@ export const searchWalkways = async (params: WalkwayParams) => {
  */
 export const getWalkwayDetail = async (walkwayId: number) => {
   try {
-    const { data: response } = await instance.get<WalkwayDetailResponse>(
+    const { data: response } = await instance.get<WalkwayDetail>(
       `/walkways/${walkwayId}`
     );
 
-    if (!response.isSuccess) {
-      throw new Error(response.message);
-    }
-
-    return response.data;
+    return response;
   } catch (error) {
     const axiosError = error as AxiosError<ApiErrorResponse>;
     throw new Error(
@@ -75,19 +66,15 @@ export const uploadCourseImage = async (courseImage: File) => {
     const formData = new FormData();
     formData.append("courseImage", courseImage);
 
-    const { data: response } = await instance.post<
-      ApiResponseFormat<{ courseImageId: number }>
-    >("/walkways/image", formData, {
+    const { data: response } = await instance.post
+      <{ courseImageId: number }>
+    ("/walkways/image", formData, {
       headers: {
         "Content-Type": "multipart/form-data",
       },
     });
 
-    if (!response.isSuccess) {
-      throw new Error(response.message);
-    }
-
-    return response.data.courseImageId;
+    return response.courseImageId;
   } catch (error) {
     const axiosError = error as AxiosError<ApiErrorResponse>;
     throw new Error(
@@ -101,15 +88,9 @@ export const uploadCourseImage = async (courseImage: File) => {
  */
 export const createWalkway = async (walkwayData: CreateWalkwayType) => {
   try {
-    const { data: response } = await instance.post<
-      ApiResponseFormat<{ walkwayId: number }>
-    >("/walkways", walkwayData);
-
-    if (!response.isSuccess) {
-      throw new Error(response.message);
-    }
-
-    return response.data.walkwayId;
+    const { data: response } = await instance.post<{ walkwayId: number }>
+    ("/walkways", walkwayData);
+    return response.walkwayId;
   } catch (error) {
     const axiosError = error as AxiosError<ApiErrorResponse>;
     throw new Error(
@@ -126,22 +107,11 @@ export const updateWalkway = async (
   walkwayData: UpdateWalkwayType
 ) => {
   try {
-    const response = await instance.put<ApiResponseFormat<number>>(
+    const response = await instance.put<number>(
       `/walkways/${walkwayId}`,
       walkwayData
     );
-
-    // 204 응답은 성공으로 처리
-    if (response.status === 204) {
-      return true;
-    }
-
-    // 200 응답 처리
-    if (!response.data.isSuccess) {
-      throw new Error(response.data.message);
-    }
-
-    return response.data.data;
+    return response.data;
   } catch (error) {
     const axiosError = error as AxiosError<ApiErrorResponse>;
     throw new Error(
@@ -159,7 +129,7 @@ export const getMyWalkways = async ({
   preview = false,
 }: FetchWalkwaysOptions = {}): Promise<MyWalkwaysResponse> => {
   try {
-    const { data: response } = await instance.get<MyWalkwaysApiResponse>(
+    const { data: response } = await instance.get<MyWalkwaysResponse>(
       "/users/walkways/upload",
       {
         params: {
@@ -169,11 +139,7 @@ export const getMyWalkways = async ({
       }
     );
 
-    if (!response.isSuccess) {
-      throw new Error(response.message);
-    }
-
-    return response.data;
+    return response;
   } catch (error) {
     const axiosError = error as AxiosError<ApiErrorResponse>;
     throw new Error(
@@ -195,15 +161,11 @@ export const createWalkwayHistory = async (
   historyData: { time: number; distance: number }
 ) => {
   try {
-    const { data: response } = await instance.post<
-      ApiResponseFormat<WalkwayHistoryResponse>
-    >(`/walkways/${walkwayId}/history`, historyData);
+    const { data: response } = await instance.post
+      <WalkwayHistoryResponse>
+    (`/walkways/${walkwayId}/history`, historyData);
 
-    if (!response.isSuccess) {
-      throw new Error(response.message);
-    }
-
-    return response.data;
+    return response;
   } catch (error) {
     const axiosError = error as AxiosError<ApiErrorResponse>;
     throw new Error(

--- a/src/apis/walkway.type.ts
+++ b/src/apis/walkway.type.ts
@@ -1,5 +1,3 @@
-import { ApiResponseFormat } from "src/apis/api.type";
-
 export interface Location {
   latitude: number;
   longitude: number;
@@ -21,7 +19,7 @@ export interface Walkway {
 }
 
 export interface WalkwaysResponse {
-  walkways: Walkway[];
+  data: Walkway[];
   hasNext: boolean;
 }
 
@@ -35,8 +33,6 @@ export interface WalkwayParams {
 }
 
 export type SortOption = "liked" | "rating";
-
-export type WalkwaysApiResponse = ApiResponseFormat<WalkwaysResponse>;
 
 // 디테일 조회 타입
 export interface WalkwayDetail {
@@ -57,7 +53,6 @@ export interface WalkwayDetail {
   course: Location[];
 }
 
-export type WalkwayDetailResponse = ApiResponseFormat<WalkwayDetail>;
 
 // 등록 타입
 export interface CreateWalkwayType {
@@ -104,11 +99,10 @@ export interface FetchWalkwaysOptions {
 }
 
 export interface MyWalkwaysResponse {
-  walkways: Trail[];
+  data: Trail[];
   hasNext: boolean;
 }
 
-export type MyWalkwaysApiResponse = ApiResponseFormat<MyWalkwaysResponse>;
 
 // 이용한 산책로 내역
 export interface WalkwayHistoryResponse {

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -146,28 +146,28 @@ function Main() {
       });
 
       setWalkways((prev) =>
-        reset ? response.walkways : [...prev, ...response.walkways]
+        reset ? response.data : [...prev, ...response.data]
       );
       setHasMore(response.hasNext);
 
-      if (response.walkways.length > 0) {
+      if (response.data.length > 0) {
         const newLastId =
-          response.walkways[response.walkways.length - 1]?.walkwayId;
+          response.data[response.data.length - 1]?.walkwayId;
         console.log("📌 응답에서 추출한 새로운 lastId:", newLastId);
         setLastId(newLastId);
       }
 
       if (reset) {
         const newLikedPaths = Object.fromEntries(
-          response.walkways.map((walkway) => [
-            walkway.walkwayId,
-            walkway.isLike,
+          response.data.map((data) => [
+            data.walkwayId,
+            data.isLike,
           ])
         );
         const newLikeCounts = Object.fromEntries(
-          response.walkways.map((walkway) => [
-            walkway.walkwayId,
-            walkway.likeCount,
+          response.data.map((data) => [
+            data.walkwayId,
+            data.likeCount,
           ])
         );
         setLikedPaths(newLikedPaths);

--- a/src/pages/mypage/ReviewableHistory.tsx
+++ b/src/pages/mypage/ReviewableHistory.tsx
@@ -56,13 +56,13 @@ function ReviewableHistory() {
       });
       setReviews((prevReviews) => [
         ...prevReviews,
-        ...response.walkwayHistories,
+        ...response.data,
       ]);
 
-      if (response.walkwayHistories.length > 0) {
+      if (response.data.length > 0) {
         lastIdRef.current =
-          response.walkwayHistories[
-            response.walkwayHistories.length - 1
+          response.data[
+            response.data.length - 1
           ].walkwayId;
       }
       //setHasNext(response.hasNext);

--- a/src/pages/mypage/TrailListPage.tsx
+++ b/src/pages/mypage/TrailListPage.tsx
@@ -25,11 +25,6 @@ const List = styled.div`
   gap: 16px;
 `;
 
-// const LoadingSpinner = styled.div`
-//   text-align: center;
-//   padding: 20px;
-// `;
-
 const ErrorMessage = styled.div`
   color: red;
   text-align: center;
@@ -57,12 +52,12 @@ function TrailListPage() {
         lastId: lastIdRef.current,
       });
 
-      setTrails((prev) => [...prev, ...response.walkways]);
+      setTrails((prev) => [...prev, ...response.data]);
       setHasNext(response.hasNext);
 
-      if (response.walkways.length > 0) {
+      if (response.data.length > 0) {
         const newLastId =
-          response.walkways[response.walkways.length - 1].walkwayId;
+          response.data[response.data.length - 1].walkwayId;
         console.log("📌 응답에서 추출한 새로운 lastId:", newLastId);
         lastIdRef.current = newLastId;
       }
@@ -104,7 +99,7 @@ function TrailListPage() {
         observer.current.disconnect();
       }
     };
-  }, []);
+  }, [loadTrails]);
 
   const handleCardClick = useCallback(
     (walkwayId: number) => {

--- a/src/pages/mypage/TrailReviewPage.tsx
+++ b/src/pages/mypage/TrailReviewPage.tsx
@@ -45,12 +45,12 @@ function TrailReviewPage() {
         lastId: lastIdRef.current,
       });
 
-      setReviews((prev) => [...prev, ...response.reviews]);
+      setReviews((prev) => [...prev, ...response.data]);
       setHasNext(response.hasNext);
 
-      if (response.reviews.length > 0) {
+      if (response.data.length > 0) {
         const newLastId =
-          response.reviews[response.reviews.length - 1].reviewId;
+          response.data[response.data.length - 1].reviewId;
         console.log("📌 응답에서 추출한 새로운 lastId:", newLastId);
         lastIdRef.current = newLastId;
       }

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -167,9 +167,9 @@ function MyPage() {
           ]);
 
         setUserProfile(profile);
-        setPreviewTrails(walkwaysResponse.walkways);
-        setPreviewHistory(historyReview.walkwayHistories ?? []);
-        setReviews(userReviews.reviews || []);
+        setPreviewTrails(walkwaysResponse.data);
+        setPreviewHistory(historyReview.data ?? []);
+        setReviews(userReviews.data || []);
         setError(null);
       } catch (err) {
         setError("데이터를 불러오는데 실패했습니다.");
@@ -284,11 +284,11 @@ function MyPage() {
             </Button>
           </SeeAll>
           <Items>
-            {previewHistory.map((history) => (
+            {previewHistory.map((data) => (
               <HistoryCard
-                key={history.walkwayId}
-                history={history}
-                onClick={() => handleHistoryClick(history)}
+                key={data.walkwayId}
+                history={data}
+                onClick={() => handleHistoryClick(data)}
               />
             ))}
           </Items>

--- a/src/pages/splash/index.tsx
+++ b/src/pages/splash/index.tsx
@@ -18,7 +18,7 @@ export default function Splash() {
         console.log("스플래시 화면에서 받아온 현재 위치:", location);
 
         const response = await instance.post("/dev/token/expired");
-        const { accessTokenExpired, refreshTokenExpired } = response.data.data;
+        const { accessTokenExpired, refreshTokenExpired } = response.data;
 
         if (!accessTokenExpired && !refreshTokenExpired) {
           setTimeout(() => navigate("/navigation"), 2000);


### PR DESCRIPTION
## #️⃣ 이슈 번호

close:
- #DF-93

## 📝 작업 내용
- 백엔드 리팩토링에 따른 코드 변경
- 성공시 응답 기본포맷 삭제 (이유: isSuccess(성공여부)는 http status에서 알 수 있고, 성공 시 message는 데이터 렌더링시 프론트에서 사용하지 않음)
- 기본 조회, 페이징 조회 구조 변경 (이미지 참고)
![image](https://github.com/user-attachments/assets/e11edda5-0d34-4421-ba97-61845d3b0c37)
![image](https://github.com/user-attachments/assets/dd2551e9-c5fe-41dd-a3ff-9502d66538e5)

## 💬 리뷰 요구사항(선택)
- `trail.ts`, `TrailListLikePage.tsx` 페이지는 미구현상태라 변경하지 않았습니다. 구현시 반영해주세요.
