### PR TITLE
[DF-92] [QA] 검색 결과 클릭시 해당 위치로 이동되지 않는 문제 해결

### DIFF
--- a/src/pages/main/components/SearchResult.tsx
+++ b/src/pages/main/components/SearchResult.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef, useEffect } from "react";
 import styled from "styled-components";
 import { theme } from "../../../styles/colors/theme";
 
@@ -57,6 +57,7 @@ interface SearchResultsProps {
   results: SearchResult[];
   /** 결과 선택 핸들러 */
   onSelect: (result: SearchResult) => void;
+  onOutsideClick?: () => void;
 }
 
 /**
@@ -64,13 +65,36 @@ interface SearchResultsProps {
  * @param props - SearchResultsProps
  * @returns 검색 결과 목록 또는 null
  */
-const SearchResults = ({ results, onSelect }: SearchResultsProps) => {
+const SearchResults = ({ results, onSelect, onOutsideClick }: SearchResultsProps) => {
+  const resultsRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (resultsRef.current && !resultsRef.current.contains(event.target as Node)) {
+        if (results.length > 0) {
+          onOutsideClick?.();
+        }
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [results, onOutsideClick]);
+
   if (results.length === 0) return null;
 
   return (
-    <ResultsContainer>
+    <ResultsContainer ref={resultsRef}>
       {results.map((result, index) => (
-        <ResultItem key={index} onClick={() => onSelect(result)}>
+        <ResultItem 
+          key={index} 
+          onClick={(e) => {
+            e.stopPropagation();
+            onSelect(result);
+          }}
+        >
           <PlaceName>{result.placeName}</PlaceName>
           <Address>{result.address}</Address>
         </ResultItem>

--- a/src/pages/main/header/components/SearchInput.tsx
+++ b/src/pages/main/header/components/SearchInput.tsx
@@ -44,7 +44,6 @@ interface SearchBarProps {
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
   onSearch: () => void;
   className?: string;
-  onOutsideClick?: () => void;  // 외부 클릭 핸들러 추가
 }
 
 const SearchBar = ({
@@ -53,22 +52,9 @@ const SearchBar = ({
   value,
   onSearch,
   className,
-  onOutsideClick
 }: SearchBarProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
-        onOutsideClick?.();
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [onOutsideClick]);
 
   const handleKeyPress = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -394,11 +394,11 @@ function Main() {
             value={searchValue}
             onChange={handleSearchChange}
             onSearch={handleSearch}
-            onOutsideClick={() => setSearchResults([])}
           />
           <SearchResults
             results={searchResults}
             onSelect={handleResultSelect}
+            onOutsideClick={() => setSearchResults([])}
           />
         </SearchBarContainer>
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

close:
- #DF-92

## 📝 작업 내용
## 문제 상황
- 검색 결과 위치를 클릭했을 때 선택한 위치로 지도가 이동하지 않는 버그
- 클릭 이벤트가 제대로 처리되기 전에 검색 결과창이 사라지는 문제

## 문제 원인
- `onOutsideClick` 핸들러가 `SearchResults`가 아닌 `SearchBar`에 잘못 적용됨!!
- `SearchResults`가 `SearchBar`의 참조 영역 외부로 간주되어, 검색 결과를 클릭할 때 `onOutsideClick` 핸들러가 작동하는 문제가 있었음
- 이로 인해 선택 처리가 되기 전에 검색 결과가 초기화됨

## 수정 내용
- `onOutsideClick`핸들러를 `SearchResults`에 적용!
- 검색 결과 항목의 onClick 핸들러에 `stopPropagation()` 추가

## 📝 캡쳐
<img width="200" alt="스크린샷 2025-03-12 16 31 53" src="https://github.com/user-attachments/assets/1bc2908b-80c0-40c1-81fe-fdde4d142b4f" />
<img width="200" alt="스크린샷 2025-03-12 16 32 08" src="https://github.com/user-attachments/assets/c73d9f07-10c5-4628-86c0-9f22a243f2f6" />
<img width="200" alt="스크린샷 2025-03-12 16 32 02" src="https://github.com/user-attachments/assets/d5fb73a0-603d-4b7e-9b62-6a2b33c52353" />
