### PR TITLE
[DF-100] 여러 개의 토스트 컴포넌트가 동시에 표시되는 문제 해결

### DIFF
--- a/src/components/toast/ToastComponent.tsx
+++ b/src/components/toast/ToastComponent.tsx
@@ -1,0 +1,64 @@
+import React, { memo } from "react";
+import styled from "styled-components";
+import { FaRegCheckCircle } from "react-icons/fa";
+import { MdError } from "react-icons/md";
+import { theme } from "src/styles/colors/theme";
+import { Toast } from "src/types/toast.type";
+
+export const ToastContainer = styled.div`
+  position: fixed;
+  bottom: 100px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+  width: calc(100vw - 40px);
+  max-width: 430px;
+`;
+
+const StyledToast = styled.div<{ type: "success" | "error"; visible: boolean }>`
+  border-radius: 20px;
+  font-size: 15px;
+  font-weight: 500;
+  color: ${theme.White};
+  background-color: ${theme.Gray800};
+  height: 100%;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  opacity: ${props => props.visible ? "0.9" : "0"};
+  padding: 15px 10px;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  transition: opacity 0.3s ease-in-out;
+  will-change: opacity;
+  pointer-events: ${props => props.visible ? "auto" : "none"};
+`;
+
+const IconWrapper = styled.div<{ type: "success" | "error" }>`
+  color: ${theme.White};
+`;
+
+const Message = styled.span`
+  flex: 1;
+`;
+
+interface ToastComponentProps {
+  toast: Toast | null;
+  visible: boolean;
+}
+
+const ToastComponent = memo(({ toast, visible }: ToastComponentProps) => {
+  if (!toast) return null;
+  
+  return (
+    <StyledToast type={toast.type} visible={visible}>
+      <IconWrapper type={toast.type}>
+        {toast.type === "success" ? <FaRegCheckCircle /> : <MdError />}
+      </IconWrapper>
+      <Message>{toast.message}</Message>
+    </StyledToast>
+  );
+});
+
+export default ToastComponent;


### PR DESCRIPTION
## #️⃣ 이슈 번호

close:
- #DF-100

## 📝 작업 내용
문제상황:
<img width="348" alt="스크린샷 2025-03-20 01 48 01" src="https://github.com/user-attachments/assets/e23bfcb3-54ad-4871-b723-83ac2b3df2fa" />

- 여러 토스트 메시지를 연속으로 발생시켜도 하나의 토스트만 표시되도록 수정
- `useMemo`를 통한 컨텍스트 값 최적화
- `useCallback` 사용으로 함수 재생성 최소화
  - `toast`, `visible` 값이 변경될 때만 함수 재생성
- 토스트 UI 컴포넌트와 상태 관리 로직을 별도 파일로 분리

https://github.com/user-attachments/assets/2caf039d-3acf-4ae3-a6f8-3e245a839628

