### PR TITLE
[DF-101] 산책로 검색 및 조회 페이지 ui/ux 개선

### DIFF
--- a/src/components/bottomsheet/BottomSheet.tsx
+++ b/src/components/bottomsheet/BottomSheet.tsx
@@ -1,178 +1,183 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
-import styled from 'styled-components';
+import React, { useState, useEffect, useCallback, useRef } from "react";
+import styled from "styled-components";
 
 interface BottomSheetProps {
-    isOpen: boolean;
-    onClose: () => void;
-    onOpen: () => void;
-    children: React.ReactNode;
-    maxHeight?: string;
-    minHeight?: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onOpen: () => void;
+  children: React.ReactNode;
+  maxHeight?: string;
+  minHeight?: string;
 }
 
 const Overlay = styled.div<{ $isOpen: boolean }>`
-    position: fixed;
-    margin: 0 auto;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: rgba(0, 0, 0, 0.1);
-    opacity: ${props => props.$isOpen ? 1 : 0};
-    visibility: ${props => props.$isOpen ? 'visible' : 'hidden'};
-    transition: opacity 0.3s ease-out, visibility 0.3s ease-out;
-    z-index: 9;
-    max-width: 430px;
+  position: fixed;
+  margin: 0 auto;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.1);
+  opacity: ${(props) => (props.$isOpen ? 1 : 0)};
+  visibility: ${(props) => (props.$isOpen ? "visible" : "hidden")};
+  transition: opacity 0.3s ease-out, visibility 0.3s ease-out;
+  z-index: 9;
+  max-width: 430px;
 `;
 
 const SheetContainer = styled.div<{
-    $isOpen: boolean;
-    $maxHeight: string;
-    $minHeight: string;
-    $translateY: number;
+  $isOpen: boolean;
+  $maxHeight: string;
+  $minHeight: string;
+  $translateY: number;
 }>`
-    position: fixed;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    height: ${props => props.$maxHeight};
-    max-width: 430px;
-    margin: 0 auto;
-    background-color: white;
-    border-top-left-radius: 20px;
-    border-top-right-radius: 20px;
-    box-shadow: 0px -5px 10px 0px rgba(0, 0, 0, 0.1);
-    transition: transform 0.3s ease-out;
-    transform: translateY(${props => 
-        props.$isOpen 
-            ? `${props.$translateY}px`
-            : `calc(100% - ${props.$minHeight})`
-    });
-    z-index: 10;
-    touch-action: none;
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: ${(props) => props.$maxHeight};
+  max-width: 430px;
+  margin: 0 auto;
+  background-color: white;
+  border-top-left-radius: 20px;
+  border-top-right-radius: 20px;
+  box-shadow: 0px -5px 10px 0px rgba(0, 0, 0, 0.1);
+  transition: transform 0.3s ease-out;
+  transform: translateY(
+    ${(props) =>
+      props.$isOpen
+        ? `${props.$translateY}px`
+        : `calc(100% - ${props.$minHeight})`}
+  );
+  z-index: 10;
+  touch-action: none;
 `;
 
 const DraggableArea = styled.div`
-    height: 32px;
-    width: 100%;
-    cursor: grab;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background-color: white;
-    border-top-left-radius: 20px;
-    border-top-right-radius: 20px;
+  height: 32px;
+  width: 100%;
+  cursor: grab;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: white;
+  border-top-left-radius: 20px;
+  border-top-right-radius: 20px;
 `;
 
 const Handle = styled.div`
-    width: 40px;
-    height: 4px;
-    border-radius: 2px;
-    background-color: #d0d0d0;
+  width: 40px;
+  height: 4px;
+  border-radius: 2px;
+  background-color: #d0d0d0;
 `;
 
 const Content = styled.div`
-    padding: 0 20px 20px;
-    overflow: scroll;
-    background-color: white;
-    height: calc(100% - 32px);
+  padding: 0 20px 20px;
+  overflow: scroll;
+  background-color: white;
+  height: calc(100% - 32px);
 `;
 
-export const BottomSheet = ({ 
-    isOpen, 
-    onClose, 
-    onOpen, 
-    children, 
-    maxHeight = "85vh",
-    minHeight = "0vh"
-}: BottomSheetProps ) => {
-    const [translateY, setTranslateY] = useState(0);
-    const [startY, setStartY] = useState(0);
-    const [isDragging, setIsDragging] = useState(false);
-    const sheetRef = useRef<HTMLDivElement>(null);
+export const BottomSheet = ({
+  isOpen,
+  onClose,
+  onOpen,
+  children,
+  maxHeight = "85vh",
+  minHeight = "0vh",
+}: BottomSheetProps) => {
+  const [translateY, setTranslateY] = useState(0);
+  const [startY, setStartY] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+  const sheetRef = useRef<HTMLDivElement>(null);
 
-    const getHeight = (vh: string) => {
-        return (window.innerHeight * parseInt(vh)) / 100;
-    };
+  const getHeight = (vh: string) => {
+    return (window.innerHeight * parseInt(vh)) / 100;
+  };
 
-    const handleTouchStart = useCallback((e: React.TouchEvent) => {
-        setStartY(e.touches[0].clientY);
-        setIsDragging(true);
-    }, []);
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    setStartY(e.touches[0].clientY);
+    setIsDragging(true);
+  }, []);
 
-    const handleTouchMove = useCallback((e: React.TouchEvent) => {
-        if (!isDragging) return;
+  const handleTouchMove = useCallback(
+    (e: React.TouchEvent) => {
+      if (!isDragging) return;
 
-        const currentY = e.touches[0].clientY;
-        const diff = currentY - startY;
-        const maxSheetHeight = getHeight(maxHeight.replace('vh', ''));
-        const minSheetHeight = getHeight(minHeight.replace('vh', ''));
-        const maxTranslate = maxSheetHeight - minSheetHeight;
+      const currentY = e.touches[0].clientY;
+      const diff = currentY - startY;
+      const maxSheetHeight = getHeight(maxHeight.replace("vh", ""));
+      const minSheetHeight = getHeight(minHeight.replace("vh", ""));
+      const maxTranslate = maxSheetHeight - minSheetHeight;
 
-        if (isOpen) {
-            if (diff >= 0 && diff <= maxTranslate) {
-                setTranslateY(diff);
-            }
-        } else {
-            if (diff <= 0 && Math.abs(diff) <= maxTranslate) {
-                setTranslateY(Math.abs(diff));
-            }
+      if (isOpen) {
+        if (diff >= 0 && diff <= maxTranslate) {
+          setTranslateY(diff);
         }
-    }, [maxHeight, minHeight, isDragging, startY, isOpen]);
-
-    const handleTouchEnd = useCallback(() => {
-        setIsDragging(false);
-        const maxSheetHeight = getHeight(maxHeight.replace('vh', ''));
-        const minSheetHeight = getHeight(minHeight.replace('vh', ''));
-        const maxTranslate = maxSheetHeight - minSheetHeight;
-        const threshold = maxTranslate / 2;
-
-        if (isOpen) {
-            if (translateY > threshold) {
-                onClose();
-            } else {
-                setTranslateY(0);
-            }
-        } else {
-            if (translateY > threshold) {
-                onOpen();
-            } else {
-                setTranslateY(0);
-            }
+      } else {
+        if (diff <= 0 && Math.abs(diff) <= maxTranslate) {
+          setTranslateY(Math.abs(diff));
         }
-    }, [translateY, maxHeight, minHeight, isOpen, onClose, onOpen]);
+      }
+    },
+    [maxHeight, minHeight, isDragging, startY, isOpen]
+  );
 
-    const handleOverlayClick = useCallback((e: React.MouseEvent) => {
-        if (e.target === e.currentTarget) {
-            onClose();
-        }
-    }, [onClose]);
+  const handleTouchEnd = useCallback(() => {
+    setIsDragging(false);
+    const maxSheetHeight = getHeight(maxHeight.replace("vh", ""));
+    const minSheetHeight = getHeight(minHeight.replace("vh", ""));
+    const maxTranslate = maxSheetHeight - minSheetHeight;
+    const threshold = maxTranslate / 2;
 
-    useEffect(() => {
+    if (isOpen) {
+      if (translateY > threshold) {
+        onClose();
+      } else {
         setTranslateY(0);
-    }, [isOpen]);
+      }
+    } else {
+      if (translateY > threshold) {
+        onOpen();
+      } else {
+        setTranslateY(0);
+      }
+    }
+  }, [translateY, maxHeight, minHeight, isOpen, onClose, onOpen]);
 
-    return (
-        <>
-            <Overlay $isOpen={isOpen} onClick={handleOverlayClick} />
-            <SheetContainer
-                ref={sheetRef}
-                $isOpen={isOpen}
-                $maxHeight={maxHeight}
-                $minHeight={minHeight}
-                $translateY={translateY}
-            >
-                <DraggableArea
-                    onTouchStart={handleTouchStart}
-                    onTouchMove={handleTouchMove}
-                    onTouchEnd={handleTouchEnd}
-                >
-                    <Handle />
-                </DraggableArea>
-                <Content>
-                    {children}
-                </Content>
-            </SheetContainer>
-        </>
-    );
+  const handleOverlayClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget) {
+        onClose();
+      }
+    },
+    [onClose]
+  );
+
+  useEffect(() => {
+    setTranslateY(0);
+  }, [isOpen]);
+
+  return (
+    <>
+      <Overlay $isOpen={isOpen} onClick={handleOverlayClick} />
+      <SheetContainer
+        ref={sheetRef}
+        $isOpen={isOpen}
+        $maxHeight={maxHeight}
+        $minHeight={minHeight}
+        $translateY={translateY}
+      >
+        <DraggableArea
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
+        >
+          <Handle />
+        </DraggableArea>
+        <Content>{children}</Content>
+      </SheetContainer>
+    </>
+  );
 };

--- a/src/components/map/CourseImage.tsx
+++ b/src/components/map/CourseImage.tsx
@@ -13,8 +13,8 @@ interface StyledImageProps extends CourseImageProps {
 }
 
 const StyledImage = styled.div<CourseImageProps>`
-  width: ${(props) => props.size || "120px"};
-  height: ${(props) => props.size || "120px"};
+  width: ${(props) => props.size || "95px"};
+  height: ${(props) => props.size || "95px"};
   border-radius: ${(props) => props.borderRadius || "10px"};
   background-image: url(${CourseImageBackground});
   background-size: cover;

--- a/src/pages/main/components/PathCard.tsx
+++ b/src/pages/main/components/PathCard.tsx
@@ -7,7 +7,7 @@ import CourseImage from "src/components/map/CourseImage";
 
 const Layout = styled.div`
   width: calc(100% - 10px);
-  padding: 17px 19px 12px;
+  padding: 15px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.25);
   border-radius: 10px;
   cursor: pointer;
@@ -93,11 +93,12 @@ const PartialStar = styled(StyledStar)<{ width: number }>`
 `;
 
 const Distance = styled.h1`
-  font-size: 38px;
+  font-size: 35px;
   font-family: "Lalezar";
   line-height: 1;
   letter-spacing: -0.05em;
   text-align: right;
+  margin-top: -30px;
 `;
 
 const StyledHeart = styled(HeartIcon)<{ $isActive: boolean }>`
@@ -164,7 +165,6 @@ export default function PathCard({
       <PathCardContainer>
         <PathContent>
           <div onClick={goDetailPage}>
-            {" "}
             <CourseImage src={pathimage} alt="산책로 이미지" />
           </div>
 
@@ -180,11 +180,12 @@ export default function PathCard({
                 </StarGroup>
               </StarContainer>
             </InfoSection>
-            <Distance>{distance}</Distance>
           </ContentWrapper>
         </PathContent>
         <StyledHeart $isActive={isLiked} onClick={handleLikeClick} />
       </PathCardContainer>
+      <Distance>{distance}</Distance>
+
     </Layout>
   );
 }

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -16,6 +16,7 @@ import GuideButton from "src/components/button/GuideButton";
 import { useNavigate } from "react-router-dom";
 import { toggleLike } from "src/apis/likedWalkway";
 import { useLocationStore } from "../../store/useLocationStore";
+import { MdOutlineInbox } from "react-icons/md";
 
 const MainContainer = styled.div`
   position: relative;
@@ -60,13 +61,6 @@ const PathCardList = styled.div`
   flex: 1;
 `;
 
-const NoWalkwaysMessage = styled.div`
-  text-align: center;
-  padding: 2rem;
-  color: ${theme.Gray500};
-  font-size: 1rem;
-`;
-
 const ErrorMessage = styled.div`
   text-align: center;
   padding: 2rem;
@@ -77,6 +71,35 @@ const ErrorMessage = styled.div`
 const LoadingSpinner = styled.div`
   text-align: center;
   padding: 1rem;
+`;
+
+const EmptyStateContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin: 20px 0;
+  width: 100%;
+`;
+
+const IconWrapper = styled.div`
+  background-color: ${theme.Gray100};
+  border-radius: 50%;
+  width: 80px;
+  height: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 16px;
+`;
+
+const NoWalkwaysMessage = styled.p`
+  font-size: 16px;
+  color: ${theme.Gray700};
+  text-align: center;
+  line-height: 1.5;
+  margin: 0;
+  font-weight: 500;
 `;
 
 interface Location {
@@ -216,7 +239,6 @@ function Main() {
     setSearchResults([]);
     setSearchValue(result.placeName);
     setIsOpen(false);
-
 
     await fetchWalkways(
       result.location.lat,
@@ -416,7 +438,7 @@ function Main() {
 
         <BottomSheet
           isOpen={isOpen}
-          maxHeight="60vh"
+          maxHeight="80vh"
           minHeight={bottomSheetHeight}
           onClose={() => {
             setIsOpen(false);
@@ -458,9 +480,16 @@ function Main() {
                 ))
               ) : (
                 !loading && (
-                  <NoWalkwaysMessage>
-                    전방 500m 부근에 등록된 산책로가 없습니다.
-                  </NoWalkwaysMessage>
+                  <>
+                    <EmptyStateContainer>
+                      <IconWrapper>
+                        <MdOutlineInbox size={40} color={theme.Gray500} />
+                      </IconWrapper>
+                      <NoWalkwaysMessage>
+                        전방 500m 부근에 등록된 산책로가 없습니다.
+                      </NoWalkwaysMessage>
+                    </EmptyStateContainer>
+                  </>
                 )
               )}
               {loading && <LoadingSpinner />}

--- a/src/pages/mypage/review/ReviewableHistory.tsx
+++ b/src/pages/mypage/review/ReviewableHistory.tsx
@@ -8,6 +8,8 @@ import TrailCardAll from "src/components/TrailCardAll_View";
 import LoadingSpinner from "src/components/loading/LoadingSpinner";
 import { getReviewRecord } from "src/apis/review";
 import { walkwayHistoryType } from "src/apis/review.type";
+import { theme } from "src/styles/colors/theme";
+import { MdRateReview } from "react-icons/md";
 
 const Wrapper = styled.div`
   display: flex;
@@ -25,15 +27,44 @@ const List = styled.div`
   gap: 16px;
 `;
 
-// const LoadingSpinner = styled.div`
-//   text-align: center;
-//   padding: 20px;
-// `;
-
 const ErrorMessage = styled.div`
   color: red;
   text-align: center;
   padding: 20px;
+`;
+
+const EmptyStateContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 70vh;
+  text-align: center;
+  padding: 0 20px;
+`;
+
+const EmptyStateMessage = styled.p`
+  font-size: 16px;
+  color: ${theme.Gray600};
+  line-height: 1.5;
+  margin: 16px 0;
+`;
+
+const ExploreButton = styled.button`
+  background-color: ${theme.Green500};
+  color: white;
+  border: none;
+  border-radius: 8px;
+  padding: 12px 24px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  margin-top: 16px;
+  transition: background-color 0.2s;
+
+  &:hover {
+    background-color: ${theme.Green600};
+  }
 `;
 
 function ReviewableHistory() {
@@ -54,16 +85,10 @@ function ReviewableHistory() {
         size: 10,
         lastId: lastIdRef.current,
       });
-      setReviews((prevReviews) => [
-        ...prevReviews,
-        ...response.data,
-      ]);
+      setReviews((prevReviews) => [...prevReviews, ...response.data]);
 
       if (response.data.length > 0) {
-        lastIdRef.current =
-          response.data[
-            response.data.length - 1
-          ].walkwayId;
+        lastIdRef.current = response.data[response.data.length - 1].walkwayId;
       }
       //setHasNext(response.hasNext);
     } catch (error) {
@@ -90,6 +115,11 @@ function ReviewableHistory() {
     },
     [navigate]
   );
+
+  const navigateToExplore = () => {
+    navigate("/main"); // 메인 화면이나 산책로 탐색 화면으로 이동
+  };
+
   return (
     <>
       <AppBar
@@ -98,13 +128,28 @@ function ReviewableHistory() {
       />
       <Wrapper>
         {error && <ErrorMessage>{error}</ErrorMessage>}
-        <List>
-          {reviews.map((review, index) => (
-            <div key={review.walkwayId}>
-              <TrailCardAll trail={review} onClick={handleHistoryClick} />
-            </div>
-          ))}
-        </List>
+
+        {!loading && reviews.length === 0 ? (
+          <EmptyStateContainer>
+            <MdRateReview size={40} color={theme.Gray400} />
+            <EmptyStateMessage>
+              리뷰를 작성할 수 있는 산책로가 없습니다.
+              <br />
+              산책로를 이용해보세요!
+            </EmptyStateMessage>
+            <ExploreButton onClick={navigateToExplore}>
+              산책로 탐색하기
+            </ExploreButton>
+          </EmptyStateContainer>
+        ) : (
+          <List>
+            {reviews.map((review) => (
+              <div key={review.walkwayId}>
+                <TrailCardAll trail={review} onClick={handleHistoryClick} />
+              </div>
+            ))}
+          </List>
+        )}
         {loading && <LoadingSpinner />}
       </Wrapper>
       <BottomNavigation />

--- a/src/pages/mypage/review/TrailReviewPage.tsx
+++ b/src/pages/mypage/review/TrailReviewPage.tsx
@@ -6,6 +6,9 @@ import BottomNavigation from "src/components/bottomNavigation";
 import AppBar from "src/components/appBar";
 import { useNavigate } from "react-router-dom";
 import TrailReviewCard from "src/components/TrailReviewCard";
+import LoadingSpinner from "src/components/loading/LoadingSpinner";
+import { MdRateReview } from "react-icons/md";
+import { theme } from "src/styles/colors/theme";
 
 const Wrapper = styled.div`
   display: flex;
@@ -23,6 +26,31 @@ const List = styled.div`
   gap: 16px;
   padding: 15px;
 `;
+
+const ErrorMessage = styled.div`
+  color: red;
+  text-align: center;
+  padding: 20px;
+`;
+
+const EmptyStateContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 70vh;
+  text-align: center;
+  padding: 0 20px;
+`;
+
+const EmptyStateMessage = styled.p`
+  font-size: 16px;
+  color: ${theme.Gray600};
+  line-height: 1.5;
+  margin: 16px 0;
+`;
+
+
 function TrailReviewPage() {
   const navigate = useNavigate();
   const [reviews, setReviews] = useState<UserReviewsType[]>([]);
@@ -87,7 +115,17 @@ function TrailReviewPage() {
     <>
       <AppBar onBack={() => navigate(-1)} title="내가 작성한 리뷰" />
       <Wrapper>
-        <List>
+      {error && <ErrorMessage>{error}</ErrorMessage>}
+
+      {!loading && reviews.length === 0 ? (
+          <EmptyStateContainer>
+            <MdRateReview size={40} color={theme.Gray400} />
+            <EmptyStateMessage>
+              아직 작성한 리뷰가 없습니다.
+            </EmptyStateMessage>
+          </EmptyStateContainer>
+        ) : (
+          <List>
           {reviews.map((review) => (
             <div>
               <TrailReviewCard
@@ -104,7 +142,12 @@ function TrailReviewPage() {
               <hr />
             </div>
           ))}
+
+          
         </List>
+        )}
+
+        {loading && <LoadingSpinner />}
       </Wrapper>
       <BottomNavigation />
     </>


### PR DESCRIPTION
## #️⃣ 이슈 번호

close:
- #DF-101

## 📝 작업 내용
- 메인 페이지의 바텀시트의 높이를 크게 하고, 산책로 카드의 크기를 작게 줄여 한 번에 보이는 산책로 카드의 양을 늘림
- 리뷰가능한 산책로, 작성한 리뷰 조회시 데이터가 없을 경우 보여줄 ui 컴포넌트 추가

## 📝 캡쳐
<img width="200" alt="스크린샷 2025-03-20 01 15 15" src="https://github.com/user-attachments/assets/66a3f833-6502-4772-bbd8-03e17ee1d0d9" />
<img width="200" alt="스크린샷 2025-03-20 01 58 28" src="https://github.com/user-attachments/assets/9d563aba-2ce7-4056-b86a-140f646c11b4" />
<img width="200" alt="스크린샷 2025-03-20 02 00 12" src="https://github.com/user-attachments/assets/9bfc77a7-7533-4b78-ab6c-8e54fc4d9631" />