### PR TITLE
[DF-92] [QA] 지도, 위치 관련 qa 수정

### DIFF
--- a/src/components/bottomNavigation/index.tsx
+++ b/src/components/bottomNavigation/index.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
-import { Link, useLocation } from 'react-router-dom';
-import styled from 'styled-components';
+import React, { useState } from "react";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import styled from "styled-components";
 import { ReactComponent as NewWay } from "../../assets/svg/NewWay.svg";
 import { ReactComponent as Home } from "../../assets/svg/Home.svg";
 import { ReactComponent as MyPage } from "../../assets/svg/MyPage.svg";
-import { theme } from 'src/styles/colors/theme';
+import { theme } from "src/styles/colors/theme";
+import { useLocationStore } from "../../store/useLocationStore";
+import ConfirmationModal from "../modal/ConfirmationModal";
 
 const NavigationBar = styled.nav`
   position: fixed;
@@ -45,40 +47,64 @@ const StyledSVG = styled.div<{ isActive: boolean }>`
     width: 24px;
     height: 24px;
     path {
-      fill: ${props => props.isActive ? theme.Green500 : 'currentColor'};
+      fill: ${(props) => (props.isActive ? theme.Green500 : "currentColor")};
     }
   }
 `;
 
 const BottomNavigation = () => {
   const location = useLocation();
+  const navigate = useNavigate();
+  const { getCurrentLocation } = useLocationStore();
+  const [isLocationAccessModalOpen, setIsLocationAccessModalOpen] =
+    useState(false);
 
   const isPathActive = (basePath: string): boolean => {
     return location.pathname.startsWith(basePath);
   };
 
+  const handleNewWayClick = async () => {
+    try {
+      await getCurrentLocation();
+      navigate("/newway");
+    } catch (error) {
+      setIsLocationAccessModalOpen(true);
+    }
+  };
+
   return (
-    <NavigationBar>
-      <NavContent>
-        <NavLink to="/newway">
-          <StyledSVG isActive={isPathActive('/newway')}>
-            <NewWay mode="create" />
-          </StyledSVG>
-        </NavLink>
+    <>
+      <NavigationBar>
+        <NavContent>
+          <div onClick={handleNewWayClick} style={{ cursor: "pointer" }}>
+            <StyledSVG isActive={isPathActive("/newway")}>
+              <NewWay />
+            </StyledSVG>
+          </div>
+          <NavLink to="/main">
+            <StyledSVG isActive={isPathActive("/main")}>
+              <Home />
+            </StyledSVG>
+          </NavLink>
 
-        <NavLink to="/main">
-          <StyledSVG isActive={isPathActive('/main')}>
-            <Home />
-          </StyledSVG>
-        </NavLink>
+          <NavLink to="/mypage">
+            <StyledSVG isActive={isPathActive("/mypage")}>
+              <MyPage />
+            </StyledSVG>
+          </NavLink>
+        </NavContent>
+      </NavigationBar>
 
-        <NavLink to="/mypage">
-          <StyledSVG isActive={isPathActive('/mypage')}>
-            <MyPage />
-          </StyledSVG>
-        </NavLink>
-      </NavContent>
-    </NavigationBar>
+      <ConfirmationModal
+        isOpen={isLocationAccessModalOpen}
+        onClose={() => setIsLocationAccessModalOpen(false)}
+        onConfirm={() => setIsLocationAccessModalOpen(false)}
+        message="디바이스의 위치 접근을 수락해주세요. 
+현재 위치를 가져오려면 위치 접근 권한이 필요합니다."
+        modalType="location"
+        confirmText="확인"
+      />
+    </>
   );
 };
 

--- a/src/components/map/MainMap.tsx
+++ b/src/components/map/MainMap.tsx
@@ -12,6 +12,7 @@ import { ReactComponent as LocationIcon } from "../../assets/svg/LocationIcon.sv
 import SelectedLocationMarker from "../../assets/svg/UserLocation.svg";
 import { SearchResult } from "../../pages/main/components/SearchResult";
 import { useLocationStore } from "../../store/useLocationStore";
+import ConfirmationModal from "../modal/ConfirmationModal";
 
 const MapContainer = styled.div`
   width: 100%;
@@ -170,18 +171,17 @@ export const MainMap = ({
   const [isDragging, setIsDragging] = useState(false);
   const [mapLevel, setMapLevel] = useState(3); 
   const mapRef = useRef<kakao.maps.Map>(null);
+  const [isLocationAccessModalOpen, setIsLocationAccessModalOpen] = useState(false);
 
   const updateUserLocation = async () => {
     try {
-      // getCurrentLocation을 호출하면 자동으로 locationStore의 currentLocation이 업데이트됨
       const location = await getCurrentLocation();
       console.log("위치 정보 업데이트:", location);
-
       setMapCenter(location);
       onCenterChange?.(location);
       onLocationButtonClick?.(location);
     } catch (error) {
-      console.error("Error updating user location:", error);
+      setIsLocationAccessModalOpen(true);
     }
   };
 
@@ -341,6 +341,16 @@ export const MainMap = ({
       >
         <StyledLocationIcon />
       </LocationButton>
+
+      <ConfirmationModal 
+        isOpen={isLocationAccessModalOpen}
+        onClose={() => setIsLocationAccessModalOpen(false)}
+        onConfirm={() => setIsLocationAccessModalOpen(false)}
+        message="디바이스의 위치 접근을 수락해주세요. 
+현재 위치를 가져오려면 위치 접근 권한이 필요합니다."
+        modalType="location"
+        confirmText="확인"
+      />
     </MapContainer>
   );
 };

--- a/src/components/map/PathMap.tsx
+++ b/src/components/map/PathMap.tsx
@@ -1,6 +1,7 @@
 import { theme } from "src/styles/colors/theme";
 import { Map, Polyline } from "react-kakao-maps-sdk";
 import styled from "styled-components";
+import { useEffect, useRef, useState } from "react";
 
 const MapContainer = styled.div`
   width: 100%;
@@ -17,22 +18,64 @@ interface PathMapProps {
 }
 
 const PathMap = ({ pathCoords }: PathMapProps) => {
+  const mapRef = useRef<kakao.maps.Map | null>(null);
+  const [mapLevel, setMapLevel] = useState(3);
+  const fitMapToBounds = () => {
+    if (!mapRef.current || !pathCoords || pathCoords.length === 0) return;
+
+    try {
+      const bounds = new window.kakao.maps.LatLngBounds();
+      pathCoords.forEach((coord) => {
+        bounds.extend(new window.kakao.maps.LatLng(coord.lat, coord.lng));
+      });
+      mapRef.current.setBounds(bounds);
+      setMapLevel(mapRef.current.getLevel());
+    } catch (error) {
+      console.error("지도 경계 설정 오류:", error);
+    }
+  };
+
+  const handleMapCreated = (map: kakao.maps.Map) => {
+    mapRef.current = map;
+    setTimeout(() => {
+      fitMapToBounds();
+    }, 100);
+  };
+
+  useEffect(() => {
+    if (mapRef.current && pathCoords && pathCoords.length > 0) {
+      setTimeout(() => {
+        fitMapToBounds();
+      }, 100);
+    }
+  }, [pathCoords]);
+
+  // 화면 크기 변경 시 경계 재설정
+  useEffect(() => {
+    const handleResize = () => {
+      setTimeout(() => {
+        fitMapToBounds();
+      }, 100);
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, [pathCoords]);
+
   if (!pathCoords || pathCoords.length === 0) {
     return <div>표시할 경로 데이터가 없습니다</div>;
   }
 
-  const center = {
-    lat: pathCoords[0].lat,
-    lng: pathCoords[0].lng,
-  };
-
   return (
     <MapContainer>
       <Map
-        center={center}
+        center={pathCoords[0] || { lat: 37.5665, lng: 126.978 }}
         style={{ width: "100%", height: "100%" }}
-        level={3}
+        level={mapLevel}
         draggable={true}
+        onCreate={handleMapCreated}
       >
         <Polyline
           path={pathCoords}

--- a/src/components/modal/ConfirmationModal.tsx
+++ b/src/components/modal/ConfirmationModal.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import styled from "styled-components";
 import Modal from "./Modal";
 import { theme } from "src/styles/colors/theme";
@@ -86,7 +87,7 @@ interface ConfirmationModalProps {
   message: ReactNode;
   cancelText?: string;
   confirmText?: string;
-  modalType?: "stop" | "done" | "back" | "delete" | "default";
+  modalType?: "stop" | "done" | "back" | "delete" | "default" | "location";
   mode?: "create" | "follow";
 }
 
@@ -102,42 +103,41 @@ const ConfirmationModal = ({
 }: ConfirmationModalProps) => {
   const getModalContent = () => {
     switch (modalType) {
+      case "location":
+        return {
+          icon: <MdWarning size={52} color={theme.Red300} />,
+          title: "위치 접근 권한 필요",
+        };
       case "stop":
         return {
           icon: <MdWarning size={52} color={theme.Red300} />,
           title: "산책 조건 미달",
-          iconColor: theme.Red300,
         };
       case "done":
         if (mode === "create") {
           return {
             icon: <MdCheckCircle size={52} color={theme.Green500} />,
             title: "산책로 등록",
-            iconColor: theme.Green500,
           };
         } else {
           return {
             icon: <MdDirectionsWalk size={52} color={theme.Following} />,
             title: "이용 완료",
-            iconColor: theme.Following,
           };
         }
       case "back":
         return {
           icon: <MdInfoOutline size={52} color={theme.Following} />,
-          iconColor: theme.Following,
         };
       case "delete":
         return {
           icon: <MdWarning size={52} color={theme.Red300} />,
           title: "산책로 삭제",
-          iconColor: theme.Red300,
         };
       default:
         return {
           icon: <MdInfoOutline size={52} color={theme.Following} />,
           title: "알림",
-          iconColor: theme.Following,
         };
     }
   };

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -1,59 +1,58 @@
-import styled from 'styled-components';
-import { ReactNode } from 'react';
+import styled from "styled-components";
+import { ReactNode } from "react";
 
 interface ModalProps {
-    isOpen: boolean;
-    onClose: () => void;
-    children: ReactNode;
-    width?: string;
-    height?: string;
+  isOpen: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  width?: string;
+  height?: string;
 }
 
 const ModalOverlay = styled.div<{ isOpen: boolean }>`
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.5);
-    display: ${({ isOpen }) => (isOpen ? 'flex' : 'none')};
-    justify-content: center;
-    align-items: center;
-    z-index: 1000;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  // background-color: rgba(0, 0, 0, 0.5);
+  display: ${({ isOpen }) => (isOpen ? "flex" : "none")};
+  justify-content: center;
+  align-items: center;
+  z-index: 9999;
 `;
 
 const ModalContainer = styled.div<{ width?: string; height?: string }>`
-    background-color: white;
-    border-radius: 12px;
-    padding: 30px;
-    width: ${({ width }) => width || '85%'};
-    max-width: ${({ width }) => width || '400px'};
-    height: ${({ height }) => height || 'auto'};
-    max-height: 90vh;
-    overflow: scroll;
-    position: relative;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  background-color: white;
+  border-radius: 12px;
+  padding: 30px;
+  width: ${({ width }) => width || "85%"};
+  max-width: ${({ width }) => width || "400px"};
+  height: ${({ height }) => height || "auto"};
+  max-height: 90vh;
+  overflow: scroll;
+  position: relative;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 `;
 
-
-export default function Modal({ 
-    isOpen, 
-    onClose, 
-    children, 
-    width, 
-    height 
+export default function Modal({
+  isOpen,
+  onClose,
+  children,
+  width,
+  height,
 }: ModalProps) {
-    const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
-        if (e.target === e.currentTarget) {
-        onClose();
-        }
-    };
+  const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
 
-    return (
-        <ModalOverlay isOpen={isOpen} onClick={handleOverlayClick}>
-        <ModalContainer width={width} height={height}>
-            {children}
-        </ModalContainer>
-        </ModalOverlay>
-    );
+  return (
+    <ModalOverlay isOpen={isOpen} onClick={handleOverlayClick}>
+      <ModalContainer width={width} height={height}>
+        {children}
+      </ModalContainer>
+    </ModalOverlay>
+  );
 }

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -256,6 +256,8 @@ function Main() {
    * 검색 실행
    */
   const handleSearch = () => {
+    setIsOpen(false);
+
     if (searchValue.trim()) {
       setSearching(true);
     }
@@ -438,7 +440,7 @@ function Main() {
 
         <BottomSheet
           isOpen={isOpen}
-          maxHeight="80vh"
+          maxHeight="75vh"
           minHeight={bottomSheetHeight}
           onClose={() => {
             setIsOpen(false);


### PR DESCRIPTION
## #️⃣ 이슈 번호

close:
- #DF-92

## 📝 작업 내용
- 메인 페이지에서 키워드 검색시 바텀시트가 닫히도록 수정
- 메인페이지와 디테일페이지에서 조회된 산책로의 전체 경로가 한눈에 보이도록 수정
- 기기 현재 위치 접근을 허용하지 않은 경우, 현재 위치 버튼과 바텀네비게이션의 산책로 생성 아이콘을 클릭할 경우 위치 관련 에러 모달이 뜨도록 수정

## 📝 캡쳐
<img width="200" alt="스크린샷 2025-03-25 22 31 19" src="https://github.com/user-attachments/assets/b8a1aedb-cacc-4fd3-85a8-2f55fe86d8c2" />
<img width="200" alt="스크린샷 2025-03-25 22 31 10" src="https://github.com/user-attachments/assets/9b8a7a74-f79c-4f9e-94d8-b9213699737b" />
<img width="200" alt="스크린샷 2025-03-25 23 29 40" src="https://github.com/user-attachments/assets/99668f78-a8c6-40de-82ab-73026623d002" />


