### PR TITLE
[DF-103] 백버튼 네비게이션 수정

### DIFF
--- a/src/components/map/CourseImage.tsx
+++ b/src/components/map/CourseImage.tsx
@@ -13,8 +13,8 @@ interface StyledImageProps extends CourseImageProps {
 }
 
 const StyledImage = styled.div<CourseImageProps>`
-  width: ${(props) => props.size || "95px"};
-  height: ${(props) => props.size || "95px"};
+  width: ${(props) => props.size || "120px"};
+  height: ${(props) => props.size || "120px"};
   border-radius: ${(props) => props.borderRadius || "10px"};
   background-image: url(${CourseImageBackground});
   background-size: cover;

--- a/src/pages/detail/index.tsx
+++ b/src/pages/detail/index.tsx
@@ -332,6 +332,31 @@ export default function PathDetails({ isMyPath = false }: PathDetailsProps) {
   };
 
   const handleBack = () => {
+    // 신규등록시 확인 페이지에서 백버튼을 누른 경우 '수정하기' 버튼을 누른 것과 동일한 기능
+    if (location.state?.from === "newRegistration") {
+      const editData = {
+        isEditMode: true,
+        walkwayId: Number(walkwayId),
+        name: walkwayDetail?.name,
+        date: walkwayDetail?.date,
+        description: walkwayDetail?.memo,
+        hashtags: walkwayDetail?.hashtags.map((tag) => tag.replace("#", "")),
+        totalDistance: walkwayDetail?.distance,
+        duration: walkwayDetail?.time,
+        accessLevel: walkwayDetail?.accessLevel,
+        coordinates: walkwayDetail?.course.map((coord) => ({
+          lat: coord.latitude,
+          lng: coord.longitude,
+        })),
+      };
+  
+      navigate("/newway/registration", {
+        state: editData,
+      });
+      return;
+    }
+
+
     // 이전 상황:
     // 마이페이지에서 내가 등록한 산책로 프리뷰를 바로 클릭했을 때
     if (location.state?.from === "mypage") {

--- a/src/pages/detail/index.tsx
+++ b/src/pages/detail/index.tsx
@@ -140,8 +140,7 @@ const EditButton = styled.button<{ isDelete?: boolean }>`
 // 해시태그 관련
 const TagsContainer = styled.div`
   display: flex;
-  flex-wrap: nowrap;
-  overflow-x: auto;
+  flex-wrap: wrap;
   gap: 5px;
   margin: 10px;
   padding-bottom: 10px;
@@ -151,7 +150,8 @@ const TagItem = styled.div`
   font-size: 12px;
   font-weight: 600;
   margin: 2px;
-  flex-shrink: 0;
+  display: inline-block;
+  white-space: nowrap;
 `;
 
 // 별점 관련
@@ -331,15 +331,29 @@ export default function PathDetails({ isMyPath = false }: PathDetailsProps) {
     }
   };
 
-    // const handleBack = () => {
-  //   if (location.state?.from === "mypage") {
-  //     navigate("/mypage");
-  //   } else if (isMyPath) {
-  //     navigate("/mypage/TrailList"); // 전체보기 페이지로 이동
-  //   } else {
-  //     navigate("/main"); // 메인으로
-  //   }
-  // };
+  const handleBack = () => {
+    // 이전 상황:
+    // 마이페이지에서 내가 등록한 산책로 프리뷰를 바로 클릭했을 때
+    if (location.state?.from === "mypage") {
+      navigate("/mypage");
+    } 
+    // 내가 등록한 산책로 리스트에서 디테일 페이지로 이동했을 때
+    else if (isMyPath) {
+      navigate("/mypage/TrailList");
+    } 
+    // 내가 좋아요한 산책로 리스트에서 ...
+    else if (location.state?.from === "favorites") {
+      navigate("/mypage/TrailList?type=favorites");
+    } 
+    // 내가 북마크한 산책로 리스트에서 ...
+    else if (location.state?.from === "bookmarks" && location.state?.bookmarkId) {
+      navigate(`/mypage/TrailList?type=bookmarks&bookmarkId=${location.state.bookmarkId}`);
+    } 
+    // 기본
+    else {
+      navigate('/main');
+    }
+  };
 
   const handleBottomSheetClose = () => {
     setIsBottomSheetOpen(false);
@@ -372,7 +386,7 @@ export default function PathDetails({ isMyPath = false }: PathDetailsProps) {
   return (
     <>
       <AppBar
-        onBack={() => navigate(-1)}
+        onBack={handleBack}
         title={isMyPath ? "내 산책로" : "산책로"}
       />
       <PageWrapper>

--- a/src/pages/main/components/PathCard.tsx
+++ b/src/pages/main/components/PathCard.tsx
@@ -60,7 +60,7 @@ const StarGroup = styled.div`
   display: flex;
   gap: 2px;
   align-items: center;
-  font-size: 13px;
+  font-size: 12px;
 `;
 
 const StarRating = styled.span`
@@ -136,6 +136,11 @@ export default function PathCard({
 }: PathCardProps) {
   const navigate = useNavigate();
 
+  const getFirstHashtag = (hashtags: string) => {
+    const tags = hashtags.split(/[\s,]+/);
+    return tags.length > 0 ? tags[0] : '';
+  };
+
   const renderStars = (rating: number) => {
     return [1, 2, 3, 4, 5].map((value) => {
       const diff = rating - (value - 1);
@@ -171,7 +176,7 @@ export default function PathCard({
           <ContentWrapper>
             <InfoSection>
               <Title>{pathname}</Title>
-              <HashTag>{hashtag}</HashTag>
+              <HashTag>{getFirstHashtag(hashtag)}</HashTag>
               <StarContainer>
                 <StarGroup>
                   <StarRating>{starCount.toFixed(1)}</StarRating>

--- a/src/pages/mypage/trailList/TrailListPage.tsx
+++ b/src/pages/mypage/trailList/TrailListPage.tsx
@@ -195,13 +195,18 @@ function TrailListPage() {
   }, [hasNext, loading, initialLoading]);
 
   const handleCardClick = (walkwayId: number) => {
-    if (type === "favorites" || type === "bookmarks") {
-      navigate(`/main/recommend/detail/${walkwayId}`);
+    if (type === "favorites") {
+      navigate(`/main/recommend/detail/${walkwayId}`, {
+        state: { from: "favorites" }
+      });
+    } else if (type === "bookmarks") {
+      navigate(`/main/recommend/detail/${walkwayId}`, {
+        state: { from: "bookmarks", bookmarkId }
+      });
     } else {
       navigate(`/mypage/myregister/${walkwayId}`);
     }
   };
-
   return (
     <>
       <AppBar onBack={() => navigate("/mypage")} title={title} />

--- a/src/pages/newway/registration.tsx
+++ b/src/pages/newway/registration.tsx
@@ -168,22 +168,24 @@ export default function Registration() {
 
   const handleTagInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     // '#' 기호 제거 및 공백을 '_'로 대체
-    const value = e.target.value.replace("#", "").replace(/\s/g, "_"); // 모든 공백을 '_'로 대체
-    setTagInput(value);
-  };
+    const value = e.target.value.replace("#", "").replace(/\s/g, "_");
+    if (value.length <= 10) {
+      setTagInput(value);
+    }  };
 
-  const handleTagInputKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter" && tagInput.trim() !== "") {
-      e.preventDefault();
-      const newTag = tagInput.trim();
-
-      // 중복 태그 방지
-      if (!tags.includes(newTag)) {
-        setTags([...tags, newTag]);
+    const handleTagInputKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter" && tagInput.trim() !== "") {
+        e.preventDefault();
+        const newTag = tagInput.trim();
+    
+        // 10자를 초과하는 태그는 추가하지 않음
+        if (newTag.length <= 10 && !tags.includes(newTag)) {
+          setTags([...tags, newTag]);
+        }
+        setTagInput("");
       }
-      setTagInput("");
-    }
-  };
+    };
+
 
   // 태그 삭제 함수 추가
   const handleTagDelete = (indexToDelete: number) => {
@@ -302,7 +304,7 @@ export default function Registration() {
         />
         <TagInputWrapper>
           <TagInput
-            placeholder={"해시태그 추가하기"}
+            placeholder={"해시태그 추가하기(각 10자이내)"}
             value={tagInput}
             onChange={handleTagInputChange}
             onKeyDown={handleTagInputKeyDown}

--- a/src/pages/newway/registration.tsx
+++ b/src/pages/newway/registration.tsx
@@ -171,21 +171,21 @@ export default function Registration() {
     const value = e.target.value.replace("#", "").replace(/\s/g, "_");
     if (value.length <= 10) {
       setTagInput(value);
-    }  };
+    }
+  };
 
-    const handleTagInputKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === "Enter" && tagInput.trim() !== "") {
-        e.preventDefault();
-        const newTag = tagInput.trim();
-    
-        // 10자를 초과하는 태그는 추가하지 않음
-        if (newTag.length <= 10 && !tags.includes(newTag)) {
-          setTags([...tags, newTag]);
-        }
-        setTagInput("");
+  const handleTagInputKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && tagInput.trim() !== "") {
+      e.preventDefault();
+      const newTag = tagInput.trim();
+
+      // 10자를 초과하는 태그는 추가하지 않음
+      if (newTag.length <= 10 && !tags.includes(newTag)) {
+        setTags([...tags, newTag]);
       }
-    };
-
+      setTagInput("");
+    }
+  };
 
   // 태그 삭제 함수 추가
   const handleTagDelete = (indexToDelete: number) => {
@@ -236,7 +236,9 @@ export default function Registration() {
           };
           const walkwayId = await createWalkway(walkwayData);
           showToast("등록이 완료되었습니다.", "success");
-          navigate(`/mypage/myregister/${walkwayId}`);
+          navigate(`/mypage/myregister/${walkwayId}`, {
+            state: { from: "newRegistration" },
+          });
         }
       } catch (error) {
         showToast("다시 한 번 시도해주세요.", "error");
@@ -289,7 +291,7 @@ export default function Registration() {
           </Content>
           <TrailInfo
             duration={pathData.duration}
-            distance={pathData.totalDistance}  // 여기서는 이미 km 단위로 받은 값을 그대로 전달함
+            distance={pathData.totalDistance} // 여기서는 이미 km 단위로 받은 값을 그대로 전달함
             isRegistration={true}
           />
         </ContentWrapper>


### PR DESCRIPTION
## #️⃣ 이슈 번호

close:
- #DF-103

## 📝 작업 내용
- 해시태그 관련 ui 수정 
  - 디테일 페이지에서 해시태그 줄바꿈 시 중간에서 끊기지 않고, 해시태그 단위로 줄바꿈 처리되도록 수정
  - PathCard의 레이아웃 크기 통일을 위해 해시태그의 첫 번째 인덱스를 대표 태그로 하여 하나만 보이도록 수정 (이유: 해시태그 개수가 많을 경우 PathCard의 height가 길어짐)
  - 무분별하게 긴 해시태그 작성을 방지하기 위해 각 태그는 10자 이내로 작성하도록 제한
- 디테일 페이지의 백버튼 네비게이션 세분화
- 신규등록시 이동한 디테일 페이지에서 백버튼 클릭시 수정하기와 동일한 기능을 수행하도록 수정

