### PR TITLE
[DF-107] 바텀시트 컴포넌트 로직 변경

### DIFF
--- a/src/assets/svg/Logout.svg
+++ b/src/assets/svg/Logout.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M17 7L15.59 8.41L18.17 11H8V13H18.17L15.59 15.58L17 17L22 12L17 7ZM4 5H12V3H4C2.9 3 2 3.9 2 5V19C2 20.1 2.9 21 4 21H12V19H4V5Z" fill="black"/>
+</svg>

--- a/src/components/appBar/index.tsx
+++ b/src/components/appBar/index.tsx
@@ -1,10 +1,11 @@
-import React from "react";
+import React, { ReactNode } from "react";
 import styled from "styled-components";
 import { ReactComponent as ArrowLeft } from "../../assets/svg/ArrowLeftIcon.svg";
 
 interface AppBarProps {
   title?: string;
   onBack?: () => void;
+  rightIcon?: ReactNode;
 }
 
 const AppBarContainer = styled.div`
@@ -22,21 +23,36 @@ const AppBarContainer = styled.div`
 const IconButton = styled.div`
   cursor: pointer;
   pointer-events: auto;
+  z-index: 2;
 `;
 
 const Title = styled.h1`
   font-size: 1.1rem;
-  flex: 1;
+  position: absolute;
+  left: 0;
+  right: 0;
   text-align: center;
+  margin: 0 auto;
+  z-index: 1;
 `;
 
-const AppBar = ({ title, onBack }: AppBarProps) => {
+const RightIconContainer = styled.div`
+  cursor: pointer;
+  pointer-events: auto;
+  margin-left: auto;
+  z-index: 2;
+`;
+
+const AppBar = ({ title, onBack, rightIcon }: AppBarProps) => {
   return (
     <AppBarContainer>
-      <IconButton onClick={onBack}>
-        <ArrowLeft />
-      </IconButton>
+      {onBack && (
+        <IconButton onClick={onBack}>
+          <ArrowLeft />
+        </IconButton>
+      )}
       <Title>{title}</Title>
+      {rightIcon && <RightIconContainer>{rightIcon}</RightIconContainer>}
     </AppBarContainer>
   );
 };

--- a/src/components/bottomNavigation/index.tsx
+++ b/src/components/bottomNavigation/index.tsx
@@ -15,7 +15,7 @@ const NavigationBar = styled.nav`
   right: 0;
   background-color: white;
   box-shadow: 0 -1px 10px rgba(0, 0, 0, 0.05);
-  z-index: 1000;
+  z-index: 1003;
   max-width: 430px;
   margin: 0 auto;
 `;

--- a/src/components/bottomsheet/BottomSheet.tsx
+++ b/src/components/bottomsheet/BottomSheet.tsx
@@ -1,183 +1,197 @@
-import React, { useState, useEffect, useCallback, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 
 interface BottomSheetProps {
   isOpen: boolean;
   onClose: () => void;
-  onOpen: () => void;
   children: React.ReactNode;
-  maxHeight?: string;
-  minHeight?: string;
+  height?: string | number;
+  minHeight?: string | number;
+  showPreview?: boolean;
+  closeOnOutsideClick?: boolean;
+  showHeader?: boolean;
+  title?: string;
 }
 
-const Overlay = styled.div<{ $isOpen: boolean }>`
+const Overlay = styled.div<{ isOpen: boolean }>`
   position: fixed;
-  margin: 0 auto;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: rgba(0, 0, 0, 0.1);
-  opacity: ${(props) => (props.$isOpen ? 1 : 0)};
-  visibility: ${(props) => (props.$isOpen ? "visible" : "hidden")};
-  transition: opacity 0.3s ease-out, visibility 0.3s ease-out;
-  z-index: 9;
-  max-width: 430px;
-`;
-
-const SheetContainer = styled.div<{
-  $isOpen: boolean;
-  $maxHeight: string;
-  $minHeight: string;
-  $translateY: number;
-}>`
-  position: fixed;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  height: ${(props) => props.$maxHeight};
-  max-width: 430px;
-  margin: 0 auto;
-  background-color: white;
-  border-top-left-radius: 20px;
-  border-top-right-radius: 20px;
-  box-shadow: 0px -5px 10px 0px rgba(0, 0, 0, 0.1);
-  transition: transform 0.3s ease-out;
-  transform: translateY(
-    ${(props) =>
-      props.$isOpen
-        ? `${props.$translateY}px`
-        : `calc(100% - ${props.$minHeight})`}
-  );
-  z-index: 10;
+  z-index: 1000;
+  opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
+  transition: opacity 0.3s ease;
+  pointer-events: ${({ isOpen }) => (isOpen ? "auto" : "none")};
   touch-action: none;
 `;
 
-const DraggableArea = styled.div`
-  height: 32px;
-  width: 100%;
-  cursor: grab;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: white;
-  border-top-left-radius: 20px;
-  border-top-right-radius: 20px;
+const Container = styled.div<{
+  isOpen: boolean;
+  height: string | number;
+  minHeight: string | number;
+  showPreview: boolean;
+}>`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: ${({ height }) =>
+    typeof height === "number" ? `${height}px` : height};
+  background-color: #fff;
+  border-top-left-radius: 16px;
+  border-top-right-radius: 16px;
+  box-shadow: 0px -4px 12px rgba(0, 0, 0, 0.1);
+  transform: ${({ isOpen, minHeight, showPreview }) =>
+    isOpen
+      ? "translateY(0)"
+      : showPreview
+      ? `translateY(calc(100% - ${
+          typeof minHeight === "number" ? `${minHeight}px` : minHeight
+        }))`
+      : "translateY(100%)"};
+  transition: transform 0.3s ease;
+  z-index: 1001;
+  overflow-y: auto;
+  touch-action: none;
 `;
 
-const Handle = styled.div`
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 16px 0 16px;
+`;
+
+const DragIndicator = styled.div`
   width: 40px;
   height: 4px;
+  background-color: #ddd;
   border-radius: 2px;
-  background-color: #d0d0d0;
+  margin: 0 auto 10px;
+  cursor: pointer;
 `;
 
 const Content = styled.div`
-  padding: 0 20px 20px;
+  padding: 16px;
   overflow: scroll;
-  background-color: white;
   height: calc(100% - 32px);
 `;
 
-export const BottomSheet = ({
+const BottomSheet = ({
   isOpen,
   onClose,
-  onOpen,
   children,
-  maxHeight = "85vh",
-  minHeight = "0vh",
+  height = "80vh",
+  minHeight = "150px",
+  showPreview = true,
+  closeOnOutsideClick = true,
 }: BottomSheetProps) => {
-  const [translateY, setTranslateY] = useState(0);
-  const [startY, setStartY] = useState(0);
+  const bottomSheetRef = useRef<HTMLDivElement>(null);
+  const startY = useRef<number>(0);
+  const currentY = useRef<number>(0);
   const [isDragging, setIsDragging] = useState(false);
-  const sheetRef = useRef<HTMLDivElement>(null);
-
-  const getHeight = (vh: string) => {
-    return (window.innerHeight * parseInt(vh)) / 100;
-  };
-
-  const handleTouchStart = useCallback((e: React.TouchEvent) => {
-    setStartY(e.touches[0].clientY);
-    setIsDragging(true);
-  }, []);
-
-  const handleTouchMove = useCallback(
-    (e: React.TouchEvent) => {
-      if (!isDragging) return;
-
-      const currentY = e.touches[0].clientY;
-      const diff = currentY - startY;
-      const maxSheetHeight = getHeight(maxHeight.replace("vh", ""));
-      const minSheetHeight = getHeight(minHeight.replace("vh", ""));
-      const maxTranslate = maxSheetHeight - minSheetHeight;
-
-      if (isOpen) {
-        if (diff >= 0 && diff <= maxTranslate) {
-          setTranslateY(diff);
-        }
-      } else {
-        if (diff <= 0 && Math.abs(diff) <= maxTranslate) {
-          setTranslateY(Math.abs(diff));
-        }
-      }
-    },
-    [maxHeight, minHeight, isDragging, startY, isOpen]
-  );
-
-  const handleTouchEnd = useCallback(() => {
-    setIsDragging(false);
-    const maxSheetHeight = getHeight(maxHeight.replace("vh", ""));
-    const minSheetHeight = getHeight(minHeight.replace("vh", ""));
-    const maxTranslate = maxSheetHeight - minSheetHeight;
-    const threshold = maxTranslate / 2;
-
-    if (isOpen) {
-      if (translateY > threshold) {
-        onClose();
-      } else {
-        setTranslateY(0);
-      }
-    } else {
-      if (translateY > threshold) {
-        onOpen();
-      } else {
-        setTranslateY(0);
-      }
-    }
-  }, [translateY, maxHeight, minHeight, isOpen, onClose, onOpen]);
-
-  const handleOverlayClick = useCallback(
-    (e: React.MouseEvent) => {
-      if (e.target === e.currentTarget) {
-        onClose();
-      }
-    },
-    [onClose]
-  );
 
   useEffect(() => {
-    setTranslateY(0);
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
   }, [isOpen]);
+
+  const resetPosition = () => {
+    if (bottomSheetRef.current) {
+      bottomSheetRef.current.style.transition = "transform 0.3s ease";
+      bottomSheetRef.current.style.transform = isOpen
+        ? "translateY(0)"
+        : `translateY(calc(100% - ${
+            typeof minHeight === "number" ? `${minHeight}px` : minHeight
+          }))`;
+    }
+  };
+
+  useEffect(() => {
+    if (!isDragging) {
+      resetPosition();
+    }
+  }, [isOpen, isDragging, minHeight]);
+
+  const handleOutsideClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (closeOnOutsideClick && e.target === e.currentTarget && isOpen) {
+      onClose();
+    }
+  };
+
+  const handleTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
+    startY.current = e.touches[0].clientY;
+    setIsDragging(true);
+    if (bottomSheetRef.current) {
+      bottomSheetRef.current.style.transition = "none";
+    }
+    e.stopPropagation();
+  };
+
+  const handleTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+
+    currentY.current = e.touches[0].clientY;
+    const diff = currentY.current - startY.current;
+
+    if (isOpen && diff > 0 && bottomSheetRef.current) {
+      bottomSheetRef.current.style.transform = `translateY(${diff}px)`;
+    } else if (!isOpen && diff < 0 && bottomSheetRef.current) {
+      const currentminHeight =
+        typeof minHeight === "number" ? minHeight : parseInt(minHeight);
+      const translateY = `calc(100% - ${currentminHeight}px - ${Math.abs(
+        diff
+      )}px)`;
+      bottomSheetRef.current.style.transform = translateY;
+    }
+  };
+
+  const handleTouchEnd = (e: React.TouchEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    setIsDragging(false);
+
+    const diff = currentY.current - startY.current;
+    const threshold = 30;
+
+    if (isOpen && diff > threshold) {
+      onClose();
+    } else if (!isOpen && diff < -threshold) {
+      onClose();
+    } else {
+      resetPosition();
+    }
+  };
+
+  const handleDragIndicatorClick = () => {
+    if (!isOpen) {
+      onClose();
+    }
+  };
 
   return (
     <>
-      <Overlay $isOpen={isOpen} onClick={handleOverlayClick} />
-      <SheetContainer
-        ref={sheetRef}
-        $isOpen={isOpen}
-        $maxHeight={maxHeight}
-        $minHeight={minHeight}
-        $translateY={translateY}
+      <Overlay isOpen={isOpen} onClick={handleOutsideClick} />
+      <Container
+        ref={bottomSheetRef}
+        isOpen={isOpen}
+        height={height}
+        minHeight={minHeight}
+        showPreview={showPreview}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
       >
-        <DraggableArea
-          onTouchStart={handleTouchStart}
-          onTouchMove={handleTouchMove}
-          onTouchEnd={handleTouchEnd}
-        >
-          <Handle />
-        </DraggableArea>
+        <Header>
+          <DragIndicator onClick={handleDragIndicatorClick} />
+        </Header>
         <Content>{children}</Content>
-      </SheetContainer>
+      </Container>
     </>
   );
 };
+
+export default BottomSheet;

--- a/src/components/bottomsheet/BottomSheet.tsx
+++ b/src/components/bottomsheet/BottomSheet.tsx
@@ -61,6 +61,7 @@ const Header = styled.div`
   justify-content: space-between;
   align-items: center;
   padding: 16px 16px 0 16px;
+  touch-action: none;
 `;
 
 const DragIndicator = styled.div`
@@ -70,12 +71,14 @@ const DragIndicator = styled.div`
   border-radius: 2px;
   margin: 0 auto 10px;
   cursor: pointer;
+  touch-action: none;
 `;
 
 const Content = styled.div`
   padding: 16px;
-  overflow: scroll;
+  overflow-y: auto;
   height: calc(100% - 32px);
+  touch-action: auto;
 `;
 
 const BottomSheet = ({
@@ -88,6 +91,8 @@ const BottomSheet = ({
   closeOnOutsideClick = true,
 }: BottomSheetProps) => {
   const bottomSheetRef = useRef<HTMLDivElement>(null);
+  const headerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
   const startY = useRef<number>(0);
   const currentY = useRef<number>(0);
   const [isDragging, setIsDragging] = useState(false);
@@ -105,9 +110,11 @@ const BottomSheet = ({
       bottomSheetRef.current.style.transition = "transform 0.3s ease";
       bottomSheetRef.current.style.transform = isOpen
         ? "translateY(0)"
-        : `translateY(calc(100% - ${
+        : showPreview
+        ? `translateY(calc(100% - ${
             typeof minHeight === "number" ? `${minHeight}px` : minHeight
-          }))`;
+          }))`
+        : "translateY(100%)";
     }
   };
 
@@ -115,7 +122,7 @@ const BottomSheet = ({
     if (!isDragging) {
       resetPosition();
     }
-  }, [isOpen, isDragging, minHeight]);
+  }, [isOpen, isDragging, minHeight, showPreview]);
 
   const handleOutsideClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if (closeOnOutsideClick && e.target === e.currentTarget && isOpen) {
@@ -123,7 +130,7 @@ const BottomSheet = ({
     }
   };
 
-  const handleTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
+  const handleHeaderTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
     startY.current = e.touches[0].clientY;
     setIsDragging(true);
     if (bottomSheetRef.current) {
@@ -132,7 +139,7 @@ const BottomSheet = ({
     e.stopPropagation();
   };
 
-  const handleTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
+  const handleHeaderTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
     e.stopPropagation();
 
     currentY.current = e.touches[0].clientY;
@@ -150,7 +157,7 @@ const BottomSheet = ({
     }
   };
 
-  const handleTouchEnd = (e: React.TouchEvent<HTMLDivElement>) => {
+  const handleHeaderTouchEnd = (e: React.TouchEvent<HTMLDivElement>) => {
     e.stopPropagation();
     setIsDragging(false);
 
@@ -172,6 +179,10 @@ const BottomSheet = ({
     }
   };
 
+  const handleContentTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+  };
+
   return (
     <>
       <Overlay isOpen={isOpen} onClick={handleOutsideClick} />
@@ -181,14 +192,21 @@ const BottomSheet = ({
         height={height}
         minHeight={minHeight}
         showPreview={showPreview}
-        onTouchStart={handleTouchStart}
-        onTouchMove={handleTouchMove}
-        onTouchEnd={handleTouchEnd}
       >
-        <Header>
+        <Header
+          ref={headerRef}
+          onTouchStart={handleHeaderTouchStart}
+          onTouchMove={handleHeaderTouchMove}
+          onTouchEnd={handleHeaderTouchEnd}
+        >
           <DragIndicator onClick={handleDragIndicatorClick} />
         </Header>
-        <Content>{children}</Content>
+        <Content 
+          ref={contentRef}
+          onTouchStart={handleContentTouchStart}
+        >
+          {children}
+        </Content>
       </Container>
     </>
   );

--- a/src/pages/detail/index.tsx
+++ b/src/pages/detail/index.tsx
@@ -17,7 +17,7 @@ import StarCount from "src/components/review/starCount";
 import { BookmarkContent } from "./bookmark/components/BookmarkContent";
 import { toggleLike } from "src/apis/likedWalkway";
 import LoadingSpinner from "src/components/loading/LoadingSpinner";
-import { BottomSheet } from "src/components/bottomsheet/BottomSheet";
+import BottomSheet from "src/components/bottomsheet/BottomSheet";
 import { useToast } from "src/hooks/useToast";
 import ConfirmationModal from "../../components/modal/ConfirmationModal";
 
@@ -224,7 +224,7 @@ export default function PathDetails({ isMyPath = false }: PathDetailsProps) {
     historyId?: number;
     canReview?: boolean;
   }>({});
-  const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState<boolean>(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const { showToast } = useToast();
 
@@ -271,9 +271,11 @@ export default function PathDetails({ isMyPath = false }: PathDetailsProps) {
       }
     }
   };
+  // 북마크 클릭 시 바텀시트 오픈
+  const toggleBottomSheet = () => setIsOpen((prev) => !prev);
 
   const handleBookmarkClick = () => {
-    setIsBottomSheetOpen(true);
+    setIsOpen(true);
   };
 
   const goToReviews = (): void => {
@@ -349,39 +351,39 @@ export default function PathDetails({ isMyPath = false }: PathDetailsProps) {
           lng: coord.longitude,
         })),
       };
-  
+
       navigate("/newway/registration", {
         state: editData,
       });
       return;
     }
 
-
     // 이전 상황:
     // 마이페이지에서 내가 등록한 산책로 프리뷰를 바로 클릭했을 때
     if (location.state?.from === "mypage") {
       navigate("/mypage");
-    } 
+    }
     // 내가 등록한 산책로 리스트에서 디테일 페이지로 이동했을 때
     else if (isMyPath) {
       navigate("/mypage/TrailList");
-    } 
+    }
     // 내가 좋아요한 산책로 리스트에서 ...
     else if (location.state?.from === "favorites") {
       navigate("/mypage/TrailList?type=favorites");
-    } 
+    }
     // 내가 북마크한 산책로 리스트에서 ...
-    else if (location.state?.from === "bookmarks" && location.state?.bookmarkId) {
-      navigate(`/mypage/TrailList?type=bookmarks&bookmarkId=${location.state.bookmarkId}`);
-    } 
+    else if (
+      location.state?.from === "bookmarks" &&
+      location.state?.bookmarkId
+    ) {
+      navigate(
+        `/mypage/TrailList?type=bookmarks&bookmarkId=${location.state.bookmarkId}`
+      );
+    }
     // 기본
     else {
-      navigate('/main');
+      navigate("/main");
     }
-  };
-
-  const handleBottomSheetClose = () => {
-    setIsBottomSheetOpen(false);
   };
 
   const openDeleteModal = () => {
@@ -410,10 +412,7 @@ export default function PathDetails({ isMyPath = false }: PathDetailsProps) {
 
   return (
     <>
-      <AppBar
-        onBack={handleBack}
-        title={isMyPath ? "내 산책로" : "산책로"}
-      />
+      <AppBar onBack={handleBack} title={isMyPath ? "내 산책로" : "산책로"} />
       <PageWrapper>
         <HeaderContainer>
           <HeaderTopBar>
@@ -510,18 +509,20 @@ export default function PathDetails({ isMyPath = false }: PathDetailsProps) {
           )}
         </ButtonContainer>
       </PageWrapper>
-      <BottomNavigation />
+
       <BottomSheet
-        isOpen={isBottomSheetOpen}
-        onClose={handleBottomSheetClose}
-        onOpen={() => setIsBottomSheetOpen(true)}
-        maxHeight="50vh"
-        minHeight="0vh"
+        isOpen={isOpen}
+        onClose={toggleBottomSheet}
+        height="50vh"
+        minHeight="0px"
+        showPreview={true}
+        closeOnOutsideClick={true}
       >
         <div>
-          <BookmarkContent onComplete={() => setIsBottomSheetOpen(false)} />
+          <BookmarkContent onComplete={() => toggleBottomSheet} />
         </div>
       </BottomSheet>
+
       <ConfirmationModal
         isOpen={isDeleteModalOpen}
         onClose={closeDeleteModal}
@@ -531,6 +532,7 @@ export default function PathDetails({ isMyPath = false }: PathDetailsProps) {
         confirmText="삭제"
         modalType="delete"
       />
+      <BottomNavigation />
     </>
   );
 }

--- a/src/pages/main/header/BottomSheetHeader.tsx
+++ b/src/pages/main/header/BottomSheetHeader.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import styled from "styled-components";
-import Divider from "../../../components/Divider";
 import { ReactComponent as DongSanTextLogo } from "../../../assets/svg/DongSanTextLogo.svg";
 import DropDownButton from "../../../components/button/DropDownButton";
 import { SortOption } from "../../../apis/walkway.type";
@@ -14,6 +13,7 @@ const DropdownContainer = styled.div`
   justify-content: space-between;
   align-items: center;
   width: 100%;
+  margin-bottom: 15px;
 `;
 
 const DropdownWrapper = styled.div`
@@ -49,7 +49,6 @@ const BottomSheetHeader = ({
           />
         </DropdownWrapper>
       </DropdownContainer>
-      <Divider />
     </Container>
   );
 };

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -2,7 +2,7 @@ import React, { useState, ChangeEvent, useEffect } from "react";
 import styled from "styled-components";
 import { AxiosError } from "axios";
 import { MainMap } from "../../components/map/MainMap";
-import { BottomSheet } from "../../components/bottomsheet/BottomSheet";
+import BottomSheet from "../../components/bottomsheet/BottomSheet";
 import BottomSheetHeader from "./header/BottomSheetHeader";
 import PathCard from "./components/PathCard";
 import SearchBar from "./header/components/SearchInput";
@@ -38,10 +38,10 @@ const SearchBarContainer = styled.div`
 `;
 
 const BottomSheetContainer = styled.div`
-  position: relative;
-  height: 100%;
   display: flex;
   flex-direction: column;
+  height: 100%;
+  width: 100%;
 `;
 
 const FixedHeader = styled.div`
@@ -49,6 +49,7 @@ const FixedHeader = styled.div`
   top: 0;
   background: white;
   z-index: 1;
+  flex-shrink: 0;
 `;
 
 const PathCardList = styled.div`
@@ -57,8 +58,9 @@ const PathCardList = styled.div`
   align-items: center;
   gap: 20px;
   padding: 10px 0 70px 0;
-  overflow: scroll;
+  overflow-y: auto;
   flex: 1;
+  -webkit-overflow-scrolling: touch;
 `;
 
 const ErrorMessage = styled.div`
@@ -110,10 +112,9 @@ interface Location {
 function Main() {
   const navigate = useNavigate();
   const { currentLocation, getCurrentLocation } = useLocationStore();
-
   // 바텀시트 상태
-  const [isOpen, setIsOpen] = useState(false);
-  const [bottomSheetHeight, setBottomSheetHeight] = useState("23vh");
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const toggleBottomSheet = () => setIsOpen((prev) => !prev);
 
   // 검색 관련 상태
   const [searchValue, setSearchValue] = useState<string>("");
@@ -292,7 +293,6 @@ function Main() {
         name: "현재 위치",
       });
       setSelectedPath([]); // 경로 초기화
-      setBottomSheetHeight("23vh");
       setIsOpen(false);
     } catch (error) {
       console.error("현재 위치 기반 산책로 조회 실패:", error);
@@ -440,13 +440,11 @@ function Main() {
 
         <BottomSheet
           isOpen={isOpen}
-          maxHeight="75vh"
-          minHeight={bottomSheetHeight}
-          onClose={() => {
-            setIsOpen(false);
-            setBottomSheetHeight("23vh");
-          }}
-          onOpen={() => setIsOpen(true)}
+          onClose={toggleBottomSheet}
+          height="75vh"
+          minHeight="180px"
+          showPreview={true}
+          closeOnOutsideClick={true}
         >
           <BottomSheetContainer>
             <FixedHeader>

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -22,6 +22,7 @@ import HistoryCard from "src/components/HistoryCard_mp";
 import LoadingSpinner from "src/components/loading/LoadingSpinner";
 import { getBookmark } from "../../apis/bookmark";
 import ConfirmationModal from "src/components/modal/ConfirmationModal";
+import { ReactComponent as Logout } from "../../assets/svg/Logout.svg";
 
 const Wrapper = styled.div`
   display: flex;
@@ -55,6 +56,7 @@ const ProfileTop = styled.div`
   align-items: flex-start;
   width: 100%;
   gap: 20px;
+  margin-bottom: 15px;
 `;
 
 const ProfileInfo = styled.div`
@@ -64,9 +66,10 @@ const ProfileInfo = styled.div`
 `;
 
 const Name = styled.div`
-  font-size: 24px;
+  font-size: 22px;
   font-weight: bold;
-  color: #054630;
+  color: ${theme.Green600};
+  margin-bottom: 5px;
 `;
 
 const Img = styled.img`
@@ -76,18 +79,6 @@ const Img = styled.img`
   border: 4px solid ${theme.White};
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
   object-fit: cover;
-`;
-
-const LogoutButton = styled.button`
-  padding: 6px;
-  background-color: ${theme.White};
-  color: ${theme.Green500};
-  border: 1px solid ${theme.Green700};
-  border-radius: 8px;
-  font-size: 13px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s ease;
 `;
 
 //내가 등록한 산책로
@@ -130,7 +121,7 @@ const Delete = styled.span`
   font-size: 12px;
   color: ${theme.Gray400};
 `;
-// API 응답 타입에 맞게 Bookmark 인터페이스 수정
+
 interface Bookmark {
   bookmarkId: number;
   name: string;
@@ -274,21 +265,21 @@ function MyPage() {
 
   return (
     <>
-      <AppBar onBack={() => navigate("/main")} title="마이 페이지" />
+      <AppBar
+        onBack={() => navigate("/main")}
+        title="마이 페이지"
+        rightIcon={<Logout onClick={handleLogout} />}
+      />{" "}
       <Wrapper>
         <Profile>
           <ProfileTop>
             <ProfileInfo>
-              <Img
-                src={profileImg}
-                alt="프로필 이미지"
-              />
+              <Img src={profileImg} alt="프로필 이미지" />
               <div>
                 <Name>{userProfile?.nickname || "이름"}</Name>
                 <div>{userProfile?.email || "이메일 정보 없음"}</div>
               </div>
             </ProfileInfo>
-            <LogoutButton onClick={handleLogout}>로그아웃</LogoutButton>
           </ProfileTop>
           <Line />
         </Profile>


### PR DESCRIPTION
## #️⃣ 이슈 번호

close:
- #DF-107

## 📝 작업 내용
- 바텀시트 컴포넌트 전체 로직 변경
  - `DraggableArea`로 드래그 영역을 제한하지 않고, 바텀시트 헤더에 터치 이벤트를 적용함
  - `translateY` 값 계산 방식 단순화
  - 스와이프로 인한 페이지 새로고침 방지
  
### 📝 바텀시트 사용예시
```
function SampleContainer() {
  const [isOpen, setIsOpen] = useState(false);
  
  const toggleBottomSheet = () => setIsOpen(prev => !prev);
  
  return (
    <div>
      <BottomSheet 
        isOpen={isOpen} 
        onClose={toggleBottomSheet}
        height="80vh" // 드래그해서 열었을 때의 높이
        minHeight="150px" // 미리보기로 보여줄 경우의 높이
        showPreview={true}
      >
        <div>바텀시트 컨텐츠를 여기에 넣어주세요.</div>
      </BottomSheet>
    </div>
  );
}
```
- 마이페이지 > 로그아웃 버튼 ui 변경
  - 앱바 컴포넌트에 오른쪽 아이콘 배치 추가

## 📝 캡쳐
<img width="300" alt="스크린샷 2025-04-15 02 49 25" src="https://github.com/user-attachments/assets/5b4e2eb7-2a3c-4e55-8b07-03550cc0a005" />

### 🛠️ 수정 전

https://github.com/user-attachments/assets/ca805951-6e39-4027-b80d-31f56e2d3098

### ⬆️ 수정 후

https://github.com/user-attachments/assets/a8bd5709-181d-4a84-a0e9-78558b266f9c

