### PR TITLE
[DF-109] 동산에 등록된 모든 산책로 조회

### DIFF
--- a/src/apis/walkway.ts
+++ b/src/apis/walkway.ts
@@ -9,6 +9,7 @@ import {
   WalkwaysResponse,
   WalkwayDetail,
   WalkwayListResponse,
+  AllWalkwayParams,
 } from "./walkway.type";
 import { ApiErrorResponse } from "src/apis/api.type";
 import { AxiosError } from "axios";
@@ -40,6 +41,32 @@ export const searchWalkways = async (params: WalkwayParams) => {
     );
   }
 };
+
+/**
+ * 모든 산책로 조회 API 호출 (위치 기반 X)
+ */
+export const getAllWalkways = async (params: AllWalkwayParams) => {
+  try {
+    const { data: response } = await instance.get<WalkwaysResponse>(
+      "/walkways/all",
+      {
+        params: {
+          sort: params.sort,
+          lastId: params.lastId,
+          size: params.size || 10,
+        },
+      }
+    );
+
+    return response;
+  } catch (error) {
+    const axiosError = error as AxiosError<ApiErrorResponse>;
+    throw new Error(
+      axiosError.response?.data?.message || "모든 산책로 조회에 실패했습니다."
+    );
+  }
+};
+
 
 /**
  * 산책로 단건 조회 API 호출

--- a/src/apis/walkway.type.ts
+++ b/src/apis/walkway.type.ts
@@ -66,7 +66,14 @@ export interface WalkwayParams {
   size?: number;
 }
 
+export interface AllWalkwayParams {
+  sort: SortOption;
+  lastId?: number | null;
+  size?: number;
+}
+
 export type SortOption = "liked" | "rating";
+export type MapOption = "all" | "current";
 
 // 디테일 조회 타입
 export interface WalkwayDetail {

--- a/src/pages/main/header/BottomSheetHeader.tsx
+++ b/src/pages/main/header/BottomSheetHeader.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import { ReactComponent as DongSanTextLogo } from "../../../assets/svg/DongSanTextLogo.svg";
 import DropDownButton from "../../../components/button/DropDownButton";
-import { SortOption } from "../../../apis/walkway.type";
+import { MapOption, SortOption } from "../../../apis/walkway.type";
 
 const Container = styled.div`
   width: 100%;
@@ -24,8 +24,10 @@ const DropdownWrapper = styled.div`
 interface BottomSheetHeaderProps {
   /** 현재 선택된 정렬 옵션 */
   sortValue: SortOption;
+  mapValue: MapOption;
   /** 정렬 옵션 변경 핸들러 */
   onSortChange: (value: string) => void;
+  onMapChange: (value: string) => void;
 }
 
 const sortOptions = [
@@ -33,14 +35,28 @@ const sortOptions = [
   { value: "rating", label: "별점순" },
 ] as const;
 
+const mapOptions = [
+  { value: "current", label: "현재위치" },
+  { value: "all", label: "모든산책로" },
+] as const;
+
 const BottomSheetHeader = ({
   sortValue,
+  mapValue,
   onSortChange,
+  onMapChange
 }: BottomSheetHeaderProps) => {
   return (
     <Container>
       <DropdownContainer>
         <DongSanTextLogo />
+        <DropdownWrapper>
+          <DropDownButton
+            options={mapOptions}
+            value={mapValue}
+            onChange={onMapChange}
+          />
+        </DropdownWrapper>
         <DropdownWrapper>
           <DropDownButton
             options={sortOptions}

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -10,7 +10,11 @@ import SearchResults, { SearchResult } from "./components/SearchResult";
 import BottomNavigation from "src/components/bottomNavigation";
 import { theme } from "src/styles/colors/theme";
 import { Walkway, SortOption, MapOption } from "../../apis/walkway.type";
-import { searchWalkways, getWalkwayDetail, getAllWalkways } from "../../apis/walkway";
+import {
+  searchWalkways,
+  getWalkwayDetail,
+  getAllWalkways,
+} from "../../apis/walkway";
 import { ApiErrorResponse } from "src/apis/api.type";
 import GuideButton from "src/components/button/GuideButton";
 import { useNavigate } from "react-router-dom";
@@ -104,6 +108,19 @@ const NoWalkwaysMessage = styled.p`
   font-weight: 500;
 `;
 
+const ViewAllButton = styled.button`
+  background-color: ${theme.Green300};
+  color: white;
+  border: none;
+  border-radius: 8px;
+  padding: 10px 25px;
+  font-size: 14px;
+  font-weight: 500;
+  margin-top: 30px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+`;
+
 interface Location {
   lat: number;
   lng: number;
@@ -176,14 +193,10 @@ function Main() {
     initializeLocation();
   }, [mapOption]);
 
-
   /**
    * 모든 산책로 조회 API 연동
    */
-  const fetchAllWalkways = async (
-    sort: SortOption,
-    reset: boolean = false
-  ) => {
+  const fetchAllWalkways = async (sort: SortOption, reset: boolean = false) => {
     try {
       setLoading(true);
       setError(null);
@@ -284,7 +297,7 @@ function Main() {
   };
 
   const handleResultSelect = async (result: SearchResult) => {
-    setMapOption("current");    
+    setMapOption("current");
     setSelectedLocation({
       latitude: result.location.lat,
       longitude: result.location.lng,
@@ -430,7 +443,7 @@ function Main() {
       }
     }
   };
-  
+
   /**
    * 좋아요 클릭 처리
    */
@@ -592,11 +605,22 @@ function Main() {
                         <MdOutlineInbox size={40} color={theme.Gray500} />
                       </IconWrapper>
                       <NoWalkwaysMessage>
-                        {mapOption === "current" 
+                        {mapOption === "current"
                           ? "전방 500m 부근에 등록된 산책로가 없습니다."
-                          : "등록된 산책로가 없습니다."
-                        }
+                          : "등록된 산책로가 없습니다."}
                       </NoWalkwaysMessage>
+
+                      {/* 현재 위치 모드에서만 버튼 표시 */}
+                      {mapOption === "current" && (
+                        <ViewAllButton
+                          onClick={() => {
+                            setMapOption("all");
+                            fetchAllWalkways(sortOption, true);
+                          }}
+                        >
+                          동산의 모든 산책로 둘러보기
+                        </ViewAllButton>
+                      )}
                     </EmptyStateContainer>
                   </>
                 )


### PR DESCRIPTION
## #️⃣ 이슈 번호

close:
- #DF-109

## 📝 작업 내용
-  메인 바텀시트 헤더에 "현재 위치" or "모든 산책로" 옵션을 선택하는 드롭다운 버튼 추가
- 현재 위치와 상관없이 모든 산책로를 조회할 수 있는 `getAllWalkways` 구현
  - API 파라미터 타입을 위한 `AllWalkwayParams` 추가
- 옵션 변경 시 `handleMapChange` 함수를 통해 관련 API 호출 처리, `fetchAllWalkways`로 모든 산책로 데이터 fetch
  - 옵션 변경 시 이전 데이터는 초기화되고 새 데이터가 로딩되도록 구현
- 지도 옵션 추가에 따라, 산책로가 없을 때 표시되는 메시지를 선택된 옵션에 따라 다르게 표시
  - 현재 위치 모드에서 산책로가 없을 때 "전방 500m 부근에 등록된 산책로가 없습니다."
  - 모든 산책로 모드에서 산책로가 없을 때 "등록된 산책로가 없습니다."
  - 현재 위치 모드에서 산책로가 없을 때 "등록된 모든 산책로 둘러보기" 버튼 추가

## 📝 캡쳐
<img width="200" alt="스크린샷 2025-04-17 00 37 20" src="https://github.com/user-attachments/assets/ad8a9364-5b4c-439c-b100-21c1dcc4af7e" />
<img width="200" alt="스크린샷 2025-04-17 00 37 33" src="https://github.com/user-attachments/assets/67cc9006-e73b-4ef0-a7d9-e62bc483b75e" />
