### PR TITLE
[DF-92] [QA] 1.0.0 배포 전 ui/ux 개선 (조회 기본값, 가이드)

### DIFF
--- a/src/components/bottomsheet/BottomSheet.tsx
+++ b/src/components/bottomsheet/BottomSheet.tsx
@@ -32,6 +32,8 @@ const Container = styled.div<{
   minHeight: string | number;
   showPreview: boolean;
 }>`
+  max-width: 430px;
+  margin: auto;
   position: fixed;
   bottom: 0;
   left: 0;

--- a/src/pages/guide/sections/SearchSection.tsx
+++ b/src/pages/guide/sections/SearchSection.tsx
@@ -37,19 +37,23 @@ const SearchSection = forwardRef<HTMLDivElement>((props, ref) => (
         <StepItem>
           <StepNumber>2</StepNumber>
           <StepContent>
-            다음과 같은 방법으로 산책로를 검색할 수 있습니다:
+            다음과 같은 방법으로 산책로를 검색할 수 있습니다.
             <List>
               <ListItem>
                 <BiChevronRight />
-                사용자의 현재 위치 근방 50m 이내의 산책로가 자동으로 검색됩니다
+                기본적으로, 동산에 등록된 모든 산책로가 검색됩니다.
               </ListItem>
               <ListItem>
                 <BiChevronRight />
-                상단 검색창에서 원하는 산책 장소를 검색
+                두 종류의 정렬 버튼을 이용하여, 현재위치 근방에 있는 산책로나 등록된 모든 산책로를 인기순 혹은 별점순으로 정렬할 수 있습니다.
               </ListItem>
               <ListItem>
                 <BiChevronRight />
-                지도를 드래그한 후 '현재 위치에서 검색' 버튼 클릭
+                상단 검색창에서 원하는 산책 장소를 검색하여 해당 위치 근방에 등록된 산책로를 조회할 수 있습니다.
+              </ListItem>
+              <ListItem>
+                <BiChevronRight />
+                지도를 드래그하여 위치를 변경한 후 검색창 하단의 '현재 위치에서 검색' 버튼 클릭하면 해당위치 근방의 산책로가 조회됩니다.
               </ListItem>
             </List>
           </StepContent>

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -149,7 +149,7 @@ function Main() {
   const [walkways, setWalkways] = useState<Walkway[]>([]);
   const [hasMore, setHasMore] = useState(false);
   const [sortOption, setSortOption] = useState<SortOption>("liked");
-  const [mapOption, setMapOption] = useState<MapOption>("current");
+  const [mapOption, setMapOption] = useState<MapOption>("all");
   const [lastId, setLastId] = useState<number | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4988,6 +4988,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@^2.3.2, fsevents@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"


### PR DESCRIPTION
## #️⃣ 이슈 번호

close:
- #DF-92

## 📝 작업 내용
- 메인 페이지 산책로 조회 시 `mapOption` 기본값을 `all`로 설정하여 사용자가 처음 바텀시트 진입 시 빈 화면을 보는 경우를 방지했습니다.
- 바텀시트에 `max-width` 속성을 추가하여 웹 환경에서 모바일뷰 영역을 벗어나지 않도록 레이아웃을 최적화했습니다.
- 문서화: 위 변경사항을 가이드 페이지에 반영하여 사용자 매뉴얼을 최신 상태로 업데이트했습니다.


