### PR TITLE
[stomp 웹소켓 통신] 같이 산책 페이지

### DIFF
--- a/src/pages/community/components/RecruitForm.tsx
+++ b/src/pages/community/components/RecruitForm.tsx
@@ -105,7 +105,10 @@ export default function RecruitForm({ onSubmit }: RecruitFormProps) {
     try {
       if (!startDate || !startTime || !endDate || !endTime || !crewId) return;
 
-      const formattedStartDate = startDate.toISOString().split("T")[0];
+      const startYear = startDate.getFullYear();
+      const startMonth = (startDate.getMonth() + 1).toString().padStart(2, "0"); // 월은 0부터 시작
+      const startDay = startDate.getDate().toString().padStart(2, "0");
+      const formattedStartDate = `${startYear}-${startMonth}-${startDay}`;
       const formattedStartTime = `${startTime
         .getHours()
         .toString()
@@ -117,7 +120,10 @@ export default function RecruitForm({ onSubmit }: RecruitFormProps) {
         .toString()
         .padStart(2, "0")}`;
 
-      const formattedEndDate = endDate.toISOString().split("T")[0];
+      const endYear = endDate.getFullYear();
+      const endMonth = (endDate.getMonth() + 1).toString().padStart(2, "0");
+      const endDay = endDate.getDate().toString().padStart(2, "0");
+      const formattedEndDate = `${endYear}-${endMonth}-${endDay}`;
       const formattedEndTime = `${endTime
         .getHours()
         .toString()

--- a/src/pages/community/detail/components/FeedTogether.tsx
+++ b/src/pages/community/detail/components/FeedTogether.tsx
@@ -4,7 +4,7 @@ import { BsClock } from "react-icons/bs";
 import styled from "styled-components";
 import { truncateText } from "src/utils/truncateText";
 
-export type FeedTogetherMode = "feed" | "crewCount" | "live";
+export type FeedTogetherMode = "feed" | "crewCount" | "live" | "cowalk";
 
 export interface FeedTogetherProps extends Partial<feedList> {
   mode: FeedTogetherMode;
@@ -50,7 +50,11 @@ export default function FeedTogether({
   return (
     <Container>
       <div style={{ marginBottom: "8px" }}>
-        <Contains>{truncateText(nickname, 4)}</Contains>
+        {mode === "cowalk" ? (
+          <Contains>{nickname}</Contains>
+        ) : (
+          <Contains>{truncateText(nickname, 4)}</Contains>
+        )}{" "}
       </div>
       {mode === "live" && (
         <>
@@ -64,7 +68,7 @@ export default function FeedTogether({
           </Contains>
         </>
       )}
-      {mode === "crewCount" && (
+      {(mode === "crewCount" || mode === "cowalk") && (
         <>
           <Contains>
             <BiRun />

--- a/src/pages/community/detail/together/index.tsx
+++ b/src/pages/community/detail/together/index.tsx
@@ -103,6 +103,7 @@ export default function Together() {
                 key={cowalkId}
                 startedAt={startedAt}
                 endedAt={endedAt}
+                cowalkId={cowalkId}
               />
             ))
           )}

--- a/src/stomp/cowalk/cowalk.ts
+++ b/src/stomp/cowalk/cowalk.ts
@@ -28,13 +28,13 @@ class CowalkStompService {
   }
 
   sendOngoing(cowalkId: number) {
-    const destination = `/app/cowalk/${cowalkId}/ongoing`;
+    const destination = `/app/walk/cowalk/${cowalkId}/ongoing`;
     this.client.publish({ destination, body: JSON.stringify({}) });
     console.log("같이산책 ongoing 전송 완료");
   }
 
   sendEnd(cowalkId: number) {
-    const destination = `/app/cowalk/${cowalkId}/end`;
+    const destination = `/app/walk/cowalk/${cowalkId}/end`;
     this.client.publish({ destination, body: JSON.stringify({}) });
     console.log("같이산책 end 전송 완료");
   }

--- a/src/stomp/cowalk/cowalk.ts
+++ b/src/stomp/cowalk/cowalk.ts
@@ -1,0 +1,57 @@
+import { Client, IMessage } from "@stomp/stompjs";
+import stompClient from "../stompClient";
+
+export interface CowalkCountPayLoad {
+  count: number;
+}
+
+class CowalkStompService {
+  private client: Client;
+  constructor() {
+    this.client = stompClient;
+  }
+  connect(onConnected?: () => void) {
+    this.client.onConnect = () => {
+      console.log("같이산책 stomp 연결 성공");
+      onConnected?.();
+    };
+    this.client.onStompError = (frame) => {
+      console.error("같이산책 stomp 에러:", frame);
+    };
+    this.client.onWebSocketClose = (event) => {
+      console.log("같이산책 stomp 연결 종료:", event);
+    };
+    this.client.activate();
+  }
+  disconnect() {
+    this.client.deactivate();
+  }
+
+  sendOngoing(cowalkId: number) {
+    const destination = `/app/cowalk/${cowalkId}/ongoing`;
+    this.client.publish({ destination, body: JSON.stringify({}) });
+    console.log("같이산책 ongoing 전송 완료");
+  }
+
+  sendEnd(cowalkId: number) {
+    const destination = `/app/cowalk/${cowalkId}/end`;
+    this.client.publish({ destination, body: JSON.stringify({}) });
+    console.log("같이산책 end 전송 완료");
+  }
+
+  subscribeCowalkCount(
+    cowalkId: number,
+    callback: (payload: CowalkCountPayLoad) => void
+  ) {
+    const topic = `/topic/walk/cowalk/${cowalkId}/count`;
+    this.client.subscribe(topic, (message: IMessage) => {
+      try {
+        const payload: CowalkCountPayLoad = JSON.parse(message.body);
+        callback(payload);
+      } catch (e) {
+        console.error("같이산책 카운트 메시지 파싱 실패:", e);
+      }
+    });
+  }
+}
+export const cowalkStompService = new CowalkStompService();


### PR DESCRIPTION
## #️⃣ 이슈 번호

close:
- #번호

## 📝 작업 내용
<img width="1710" height="1107" alt="image" src="https://github.com/user-attachments/assets/063cb92e-b0e7-46e2-9454-53c90168f692" />

### `CowalkStompService` 모듈 구현
- 메시지 전송(sendOngoing, sendEnd)으로 산책 시작과 종료를 알림
- 메시지 수신구독(subscribeCowalkCount)으로 현재 산책에 참여중인 인원수를 받아옴

### 같이산책 탭에서 stomp 연동
- 내가 신청한 같이산책에서 활성화된 "시작"버튼을 누르면 웹소켓 연결 및 산책("/newway")페이지로 이동 
- 이 경우 바로 산책 시작하도록 handleStartWalking 함수 처리

### FeedTogether 컴포넌트 개선
- `cowalk` 모드를 추가하여 같이산책인 경우에 조건부 UI렌더링 처리
- cowalk모드에서만 말줄임 처리 제외

### NewWay 페이지의 "같이 산책 stomp" 연동
- `mode === "cowalk" && cowalkId` 조건이 충족될 때 같이 산책 웹소켓 로직이 활성화됨
- connect로 호출 성공시, setIsCowalkSocketConnected(true) 상태를 설정하여 UI에 반영가능
- "이용 완료"로 산책 종료시 sendEnd를 호출하여 웹소켓 연결 해제(disconnect)
