### PR TITLE
[QA] 이미지 업로드 및 기타 에러 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "axios": "^1.7.9",
         "date-fns": "^4.1.0",
         "dayjs": "^1.11.13",
+        "heic2any": "^0.0.4",
         "react": "^18.3.1",
         "react-cookie": "^7.2.2",
         "react-datepicker": "^8.4.0",
@@ -9117,6 +9118,12 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/heic2any": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
+      "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==",
+      "license": "MIT"
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "axios": "^1.7.9",
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.13",
+    "heic2any": "^0.0.4",
     "react": "^18.3.1",
     "react-cookie": "^7.2.2",
     "react-datepicker": "^8.4.0",

--- a/src/components/imageUpload/index.tsx
+++ b/src/components/imageUpload/index.tsx
@@ -1,5 +1,10 @@
 import styled from "styled-components";
-import { useRef } from "react";
+import { useRef, useState } from "react";
+import {
+  compressImage,
+  convertHeicToJpeg,
+  isHeicFile,
+} from "src/utils/imageUtils";
 
 const UploadBox = styled.div`
   width: 150px;
@@ -14,6 +19,7 @@ const UploadBox = styled.div`
   cursor: pointer;
   overflow: hidden;
   background-color: ${({ theme }) => theme.Gray100};
+  position: relative;
 `;
 
 const PreviewImage = styled.img`
@@ -25,6 +31,28 @@ const PreviewImage = styled.img`
 const HiddenInput = styled.input`
   display: none;
 `;
+
+const LoadingOverlay = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(255, 255, 255, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  color: ${({ theme }) => theme.Gray600};
+`;
+
+const ErrorMessage = styled.div`
+  font-size: 12px;
+  color: ${({ theme }) => theme.Red500};
+  margin-top: 8px;
+  text-align: left;
+`;
+
 interface Props {
   file: File | null;
   onChange: (file: File) => void;
@@ -33,34 +61,114 @@ interface Props {
 
 export default function ImageUploader({ file, onChange, previewUrl }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [error, setError] = useState<string>("");
 
   const handleClick = () => {
-    inputRef.current?.click();
-  };
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const selected = e.target.files?.[0];
-    if (selected) {
-      onChange(selected);
+    if (!isProcessing) {
+      inputRef.current?.click();
     }
   };
+
+  const processImage = async (originalFile: File): Promise<File> => {
+    let processedFile = originalFile;
+
+    // HEIC 파일인 경우 JPEG로 변환
+    if (isHeicFile(originalFile)) {
+      console.log("HEIC 파일 감지, JPEG로 변환 중...");
+      processedFile = await convertHeicToJpeg(originalFile);
+    }
+
+    // 이미지 압축 (최대 800px)
+    console.log("이미지 압축 중...");
+    const compressedFile = await compressImage(processedFile, 800);
+
+    return compressedFile;
+  };
+
+  const handleChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = e.target.files?.[0];
+    if (!selected) return;
+
+    setIsProcessing(true);
+    setError("");
+
+    try {
+      // 파일 크기 체크 (10MB 제한)
+      const maxSize = 10 * 1024 * 1024; // 10MB
+      if (selected.size > maxSize) {
+        throw new Error("파일 크기는 10MB 이하여야 합니다.");
+      }
+
+      const allowedTypes = [
+        "image/jpeg",
+        "image/jpg",
+        "image/png",
+        "image/gif",
+        "image/webp",
+        "image/heic",
+        "image/heif",
+      ];
+
+      const isValidType =
+        allowedTypes.includes(selected.type) ||
+        /\.(jpg|jpeg|png|gif|webp|heic|heif)$/i.test(selected.name);
+
+      if (!isValidType) {
+        throw new Error(
+          "지원하지 않는 파일 형식입니다. (JPG, PNG, GIF, WebP, HEIC 파일만 지원)"
+        );
+      }
+
+      const processedFile = await processImage(selected);
+      onChange(processedFile);
+    } catch (error) {
+      console.error("이미지 처리 실패:", error);
+      setError(
+        error instanceof Error
+          ? error.message
+          : "이미지 처리 중 오류가 발생했습니다."
+      );
+    } finally {
+      setIsProcessing(false);
+      // 파일 입력 초기화 (같은 파일 재선택 가능하도록)
+      if (inputRef.current) {
+        inputRef.current.value = "";
+      }
+    }
+  };
+
+  const getPreviewSrc = () => {
+    if (file) {
+      return URL.createObjectURL(file);
+    }
+    if (previewUrl) {
+      return previewUrl;
+    }
+    return null;
+  };
+
+  const previewSrc = getPreviewSrc();
 
   return (
     <>
       <UploadBox onClick={handleClick}>
-        {file ? (
-          <PreviewImage src={URL.createObjectURL(file)} alt="preview" />
-        ) : previewUrl ? (
-          <PreviewImage src={previewUrl} alt="preview" />
+        {previewSrc ? (
+          <PreviewImage src={previewSrc} alt="preview" />
         ) : (
           "탭하여 이미지 등록"
         )}
+        {isProcessing && <LoadingOverlay>이미지 처리 중...</LoadingOverlay>}
       </UploadBox>
+
+      {error && <ErrorMessage>{error}</ErrorMessage>}
+
       <HiddenInput
         type="file"
-        accept="image/*"
+        accept="image/*,.heic,.heif"
         ref={inputRef}
         onChange={handleChange}
+        disabled={isProcessing}
       />
     </>
   );

--- a/src/pages/community/info/index.tsx
+++ b/src/pages/community/info/index.tsx
@@ -42,6 +42,8 @@ const Title = styled.div`
 `;
 const Content = styled.div`
   font-size: 16px;
+  line-height: 1.5;
+  white-space: pre-wrap;
 `;
 const Line = styled.div`
   width: 100%;
@@ -115,12 +117,12 @@ export default function CrewInfo() {
       <PageWrapper>
         <ScrollContainer>
           <Container>
-            <Title>크루 소개</Title>
+            <Title>👥 크루 소개</Title>
             <Content>{crew?.description}</Content>
           </Container>
           <Line></Line>
           <Container>
-            <Title>크루 규칙</Title>
+            <Title>📋 크루 규칙</Title>
             <Content>{crew?.rule}</Content>
           </Container>
         </ScrollContainer>

--- a/src/pages/community/search/components/SearchCrewCard.tsx
+++ b/src/pages/community/search/components/SearchCrewCard.tsx
@@ -106,7 +106,7 @@ export default function SearchCrewCard({
         <Title>{name}</Title>
         <DetailRow>
           <MdGroups />
-          {limitEnable ? `${memberCount} / ${memberLimit}명` : "제한 없음"}
+          {limitEnable ? `${memberCount} / ${memberLimit}명` : `${memberCount}명`}
         </DetailRow>
         <DetailRow>
           <MdDateRange />

--- a/src/pages/newway/index.tsx
+++ b/src/pages/newway/index.tsx
@@ -146,6 +146,7 @@ export default function NewWay() {
   const lastLocationRef = useRef<Location | null>(null);
   const startTimeRef = useRef<Date | null>(null);
   const toastShownRef = useRef(false);
+  const screenKeepAwakeToastShown = useRef(false);
   const [isSocketConnected, setIsSocketConnected] = useState(false);
 
   const [cowalkModeCount, setCowalkModeCount] = useState<number | null>(null);
@@ -209,7 +210,12 @@ export default function NewWay() {
 
     setUserLocation(newLocation);
     lastLocationRef.current = newLocation;
-  }, [geoLocation]);
+
+    if (!screenKeepAwakeToastShown.current) {
+      screenKeepAwakeToastShown.current = true;
+      showToast("정확한 위치 기록을 위해 화면이 계속 켜져있도록 해주세요!", "success");
+    }
+  }, [geoLocation, showToast]);
 
   useEffect(() => {
     const fetchCrewIds = async () => {

--- a/src/utils/imageUtils.ts
+++ b/src/utils/imageUtils.ts
@@ -1,0 +1,101 @@
+import heic2any from 'heic2any';
+
+/**
+ * 이미지 압축 함수
+ */
+export const compressImage = (file: File, maxWidth: number = 800): Promise<File> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+
+    reader.onload = (event) => {
+      const img = new Image();
+      img.src = event.target?.result as string;
+
+      img.onload = () => {
+        const canvas = document.createElement('canvas');
+        let width = img.width;
+        let height = img.height;
+
+        if (width > height) {
+          if (width > maxWidth) {
+            height *= maxWidth / width;
+            width = maxWidth;
+          }
+        } else {
+          if (height > maxWidth) {
+            width *= maxWidth / height;
+            height = maxWidth;
+          }
+        }
+
+        canvas.width = width;
+        canvas.height = height;
+
+        const ctx = canvas.getContext('2d');
+        ctx?.drawImage(img, 0, 0, width, height);
+
+        canvas.toBlob(
+          (blob) => {
+            if (blob) {
+              const compressedFile = new File([blob], file.name, {
+                type: 'image/jpeg',
+                lastModified: Date.now(),
+              });
+              resolve(compressedFile);
+            } else {
+              reject(new Error('압축 실패'));
+            }
+          },
+          'image/jpeg',
+          0.8
+        );
+      };
+
+      img.onerror = () => reject(new Error('이미지 로드 실패'));
+    };
+
+    reader.onerror = () => reject(new Error('파일 읽기 실패'));
+  });
+};
+
+/**
+ * HEIC 파일인지 확인하는 함수
+ */
+export const isHeicFile = (file: File): boolean => {
+  return (
+    file.type === 'image/heic' ||
+    file.type === 'image/heif' ||
+    file.name.toLowerCase().endsWith('.heic') ||
+    file.name.toLowerCase().endsWith('.heif')
+  );
+};
+
+/**
+ * HEIC 파일을 JPEG로 변환하는 함수
+ */
+export const convertHeicToJpeg = async (file: File): Promise<File> => {
+  try {
+    const convertedResult = await heic2any({
+      blob: file,
+      toType: 'image/jpeg',
+      quality: 0.8,
+    });
+
+    const convertedBlob = Array.isArray(convertedResult)
+      ? convertedResult[0]
+      : convertedResult;
+
+    return new File(
+      [convertedBlob], 
+      file.name.replace(/\.(heic|heif)$/i, '.jpg'), 
+      {
+        type: 'image/jpeg',
+        lastModified: Date.now(),
+      }
+    );
+  } catch (error) {
+    console.error('HEIC 변환 실패:', error);
+    throw error;
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5018,6 +5018,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@^2.3.2, fsevents@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
@@ -5265,6 +5270,11 @@ he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/he/-/he-1.2.0.tgz"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+heic2any@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz"
+  integrity sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==
 
 hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"


### PR DESCRIPTION
## #️⃣ 이슈 번호

close:
- #DF-138

## 📝 작업 내용
### 1. 크루 생성시 이미지 업로드를 실패하면 로그아웃 처리가 됨
-> 이미지 확장자, 용량 압축 유틸 함수를 구현하여, 10mb 이하의 이미지를 받고 80%효율로 압축해서 업로드함. 10mb 이상의 이미지를 첨부했을 시 에러 메세지를 반환함. 
### 2. 같이 산책하기, 크루 : 무제한 가입이 가능한 경우에도 현재 몇명이 가입했는지 숫자로 보여주자 (현재는 몇명이 가입했는지 확인 불가능)
-> 가입 인원 제한이 없는 크루의 경우에도 SearchCrewCard에 현재 가입한 크루원 수를 표시하여 보여줌

### 그외
- 크루 정보 확인 페이지에 \n 처리가 되지 않아, content에 줄바꿈 처리 css 코드를 추가함
- 산책시 백그라운드 전환시 위치 트래킹이 중단되므로 화면유지 안내 토스트를 추가함